### PR TITLE
Remove embedded javascript from HTML help

### DIFF
--- a/R/write_xlsx.R
+++ b/R/write_xlsx.R
@@ -6,12 +6,6 @@
 #' Currently supports strings, numbers, booleans and dates. Formatting options
 #' may be added in future versions.
 #'
-#' \if{html}{
-#' \out{
-#' <link rel="stylesheet" type="text/css" href="https://jeroen.github.io/clippy/clippy.min.css" media="all">
-#' <script src="https://jeroen.github.io/clippy/bundle.js"></script>
-#' }}
-#'
 #' @export
 #' @aliases writexl
 #' @useDynLib writexl C_write_data_frame_list


### PR DESCRIPTION
Today while looking up the `writexl` documentation I received an error where some javascript embedded in the HTML help file caused some of the help text to be obstructed. I think this might be an accessibility issue for some people.

After reviewing the source it looks like this is a relatively easy fix, let me know if there's anything I can do to improve the PR.

Fixes #39, #12. 