### PR TITLE
Fix Excel false leapyear issue

### DIFF
--- a/src/write_xlsx.c
+++ b/src/write_xlsx.c
@@ -154,7 +154,10 @@ SEXP C_write_data_frame_list(SEXP df_list, SEXP file, SEXP col_names, SEXP forma
         case COL_POSIXCT: {
           double val = REAL(col)[i];
           if(R_FINITE(val))
-            assert_lxw(worksheet_write_number(sheet, cursor, j, 25569 + val / (24*60*60) , NULL));
+            val = 25568.0 + val / (24*60*60);
+            if(val > 59.0)
+              val = val + 1.0;
+            assert_lxw(worksheet_write_number(sheet, cursor, j, val , NULL));
         }; continue;
         case COL_STRING:{
           SEXP val = STRING_ELT(col, i);


### PR DESCRIPTION
Fix issue where Excel treats 1900 as a leapyear and add an
extra day.

Issue #58