### PR TITLE
Update to newer github runner versions

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -19,13 +19,12 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - {os: macos-13,        r: 'release'}
           - {os: macos-14,        r: 'release'}
-          - {os: macos-15,        r: 'next'}
+          - {os: macos-latest,    r: 'next'}
           - {os: windows-latest,  r: '4.1'}
           - {os: windows-latest,  r: '4.2'}
           - {os: windows-latest,  r: 'release'}
-          - {os: windows-2025,    r: 'devel'}
+          - {os: windows-latest,  r: 'devel'}
           - {os: ubuntu-latest,   r: 'devel', http-user-agent: 'release'}
           - {os: ubuntu-latest,   r: 'release'}
           - {os: ubuntu-latest,   r: 'oldrel-1'}


### PR DESCRIPTION
Fix brownout on macos-13
Windows 2025 is now the same as windows-latest