### PR TITLE
Fix off-by-one in Date columns before 1900-03-01

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -43,6 +43,18 @@
 
 * See the new "Formatting and workbook properties" vignette.
 
+## Bug fixes
+
+* `Date` columns holding dates before 1900-03-01 were written one day too late.
+  Excel's 1900 date system wrongly treats 1900 as a leap year, and the `Date`
+  writer did not compensate for that phantom 1900-02-29 (the `POSIXct` writer
+  already did). As a result `1900-01-01` was written as `1900-01-02`, and
+  `1900-02-28` landed on the nonexistent serial 60 so readers such as `readxl`
+  returned `NA` with a warning about an "impossible 1900-02-29 datetime".
+  `Date` and `POSIXct` columns now write identical serial numbers. Dates from
+  1900-03-01 on, and all times written as `POSIXct`, are unaffected. Note
+  that dates before 1900-01-01 still have no valid Excel serial number.
+
 ## Internal
 
 * The header, hyperlink, and date/time formats that were previously hard-coded

--- a/src/write_xlsx.c
+++ b/src/write_xlsx.c
@@ -323,8 +323,17 @@ static void apply_sheet_scalars(cell_write_ctx *ctx, SEXP opts){
 static void write_cell_date(cell_write_ctx *ctx, lxw_row_t row, lxw_col_t col,
                              SEXP col_data, lxw_row_t i, lxw_format *fmt){
   double val = Rf_isReal(col_data) ? REAL(col_data)[i] : INTEGER(col_data)[i];
-  if(Rf_isReal(col_data) ? R_FINITE(val) : val != NA_INTEGER)
-    assert_lxw(worksheet_write_number(ctx->sheet, row, col, 25569 + val, fmt));
+  if(Rf_isReal(col_data) ? R_FINITE(val) : val != NA_INTEGER){
+    /* Same arithmetic as write_cell_posixct() below: R days since 1970-01-01
+       map to Excel serial 25568 + val, then +1 for every date on or after
+       1900-03-01 to skip Excel's phantom 1900-02-29 (Excel treats 1900 as a
+       leap year).  Without the correction 1900-01-01 .. 1900-02-28 are written
+       one day too late, and 1900-02-28 lands on the nonexistent serial 60. */
+    double serial = 25568.0 + val;
+    if(serial >= 60.0)
+      serial = serial + 1.0;
+    assert_lxw(worksheet_write_number(ctx->sheet, row, col, serial, fmt));
+  }
 }
 
 static void write_cell_posixct(cell_write_ctx *ctx, lxw_row_t row, lxw_col_t col,

--- a/tests/testthat/test-types.R
+++ b/tests/testthat/test-types.R
@@ -16,6 +16,79 @@ test_that("Types roundtrip properly",{
   expect_equal(input, as.data.frame(output))
 })
 
+# Extract the numeric <v> values of a written worksheet, keyed by cell
+# reference (e.g. c(A2 = 1, B2 = 1)).  Reading the raw serials straight out of
+# the XML keeps these assertions independent of readxl, so a writexl bug cannot
+# be masked by a compensating reader bug.
+sheet_serials <- function(path, part = "xl/worksheets/sheet1.xml") {
+  xml <- xlsx_part(path, part, raw = TRUE)
+  cells <- regmatches(xml, gregexpr("<c r=\"[A-Z]+[0-9]+\"[^>]*><v>[^<]*</v></c>", xml))[[1]]
+  refs <- sub("^<c r=\"([A-Z]+[0-9]+)\".*$", "\\1", cells)
+  vals <- as.numeric(sub("^.*<v>([^<]*)</v>.*$", "\\1", cells))
+  stats::setNames(vals, refs)
+}
+
+# Excel's 1900 date system pretends 1900 was a leap year, so serial 60 is the
+# nonexistent 1900-02-29 and every date from 1900-03-01 onwards is shifted by
+# one.  These serials are Excel's documented ground truth.
+date_boundary_cases <- data.frame(
+  date = as.Date(c("1900-01-01", "1900-02-28", "1900-03-01", "1970-01-01", "2020-03-01")),
+  serial = c(1, 59, 61, 25569, 43891)
+)
+
+test_that("Date and POSIXct columns write Excel's documented serial numbers", {
+  d <- date_boundary_cases$date
+  expected <- date_boundary_cases$serial
+  df <- data.frame(dt = d, pt = as.POSIXct(paste(d, "00:00:00"), tz = "UTC"))
+  serials <- sheet_serials(write_tmp(df))
+
+  # Row 1 is the header; data starts at row 2.  Column A = Date, B = POSIXct.
+  rows <- seq_along(d) + 1L
+  expect_equal(unname(serials[paste0("A", rows)]), expected)
+  expect_equal(unname(serials[paste0("B", rows)]), expected)
+
+  # The two writers must agree cell for cell, not merely both look plausible.
+  expect_equal(unname(serials[paste0("A", rows)]), unname(serials[paste0("B", rows)]))
+
+  # Serial 60 is Excel's phantom 1900-02-29 and must never be written.
+  expect_false(any(serials[paste0(c("A", "B"), rep(rows, each = 2))] == 60))
+})
+
+test_that("Integer-backed Date columns write the same serials as double-backed", {
+  d <- date_boundary_cases$date
+  int_date <- structure(as.integer(unclass(d)), class = "Date")
+  expect_identical(typeof(int_date), "integer")
+
+  serials <- sheet_serials(write_tmp(data.frame(dt = int_date)))
+  expect_equal(unname(serials[paste0("A", seq_along(d) + 1L)]), date_boundary_cases$serial)
+})
+
+test_that("NA is preserved in Date columns of either backing type", {
+  d <- c(as.Date("1900-02-28"), NA, as.Date("2020-03-01"))
+  int_date <- structure(as.integer(unclass(d)), class = "Date")
+
+  for (col in list(d, int_date)) {
+    path <- write_tmp(data.frame(dt = col))
+    serials <- sheet_serials(path)
+    # The NA cell is written as an empty cell, so no <v> exists for A3.
+    expect_equal(unname(serials[c("A2", "A4")]), c(59, 43891))
+    expect_false("A3" %in% names(serials))
+    expect_equal(as.Date(readxl::read_xlsx(path)[[1]]), d)
+  }
+})
+
+test_that("Dates around the 1900 leap-day boundary roundtrip through readxl", {
+  d <- date_boundary_cases$date
+  out <- readxl::read_xlsx(write_tmp(data.frame(dt = d)))
+  expect_equal(as.Date(out$dt), d)
+
+  # Every day of the 1900 boundary window, not just the hand-picked ones.
+  window <- seq(as.Date("1900-01-01"), as.Date("1900-03-05"), by = "day")
+  out2 <- readxl::read_xlsx(write_tmp(data.frame(dt = window)))
+  expect_equal(as.Date(out2$dt), window)
+  expect_false(anyNA(out2$dt))
+})
+
 test_that("Writing formulas", {
   df <- data.frame(
     name = c("UCLA", "Berkeley"),


### PR DESCRIPTION
write_cell_date() converted R Date values with a plain 25569 + val, with no compensation for Excel's phantom 1900-02-29 (Excel's 1900 date system wrongly treats 1900 as a leap year). write_cell_posixct() already applied that correction, so the two writers disagreed for every date before 1900-03-01:

  date        Date col  POSIXct col  Excel truth
  1900-01-01  2         1            1
  1900-02-28  60        59           59
  1900-03-01  61        61           61
  1970-01-01  25569     25569        25569
  2020-03-01  43891     43891        43891

Serial 60 is the nonexistent 1900-02-29, so 1900-02-28 was read back as NA by readxl ("NA inserted for impossible 1900-02-29 datetime") and 1900-01-01 came back as 1900-01-02.

write_cell_date() now mirrors write_cell_posixct() exactly -- offset 25568 plus the >= 60 correction -- so the two writers stay parallel. The existing NA/finite handling is unchanged, so both integer- and double-backed Date columns keep working. write_cell_posixct() is untouched.

Tests assert the raw serials in xl/worksheets/sheet1.xml rather than relying on a readxl round-trip, since a round-trip alone cannot distinguish a correct writer from a writer and reader with compensating bugs. They cover both Date and POSIXct columns, integer- and double-backed Dates, NA preservation, and every day from 1900-01-01 to 1900-03-05.