### PR TITLE
Stop silently converting POSIXct columns to UTC

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -45,6 +45,24 @@
 
 ## Bug fixes
 
+* `POSIXct` columns are no longer silently converted to UTC. Excel has no
+  concept of a time zone, so writexl now decides once per workbook:
+
+  * if every datetime in the workbook shares one time zone, the zone is dropped
+    and local wall-clock time is written -- `as.POSIXct("2025-12-01 01:00:00",
+    tz = "Australia/Perth")` now appears in Excel as `2025-12-01 01:00:00`
+    rather than `2025-11-30 17:00:00`. Daylight saving is handled per value.
+    The default `datetime_format` also loses its `" UTC"` suffix in this case,
+    since the value is no longer UTC;
+  * if the time zones differ, all datetimes are converted to UTC (as before)
+    and a warning is raised, because no single wall clock can represent them
+    all. Convert them yourself beforehand if you want something else.
+
+  Datetimes inside [xl_cell_general()] cells are included in this survey.
+  Supplying your own `datetime_format` overrides the label either way. Code
+  that relied on the previous behaviour of always writing the UTC instant will
+  see shifted values when a non-UTC time zone is used throughout.
+
 * `Date` columns holding dates before 1900-03-01 were written one day too late.
   Excel's 1900 date system wrongly treats 1900 as a leap year, and the `Date`
   writer did not compensate for that phantom 1900-02-29 (the `POSIXct` writer

--- a/R/write_xlsx.R
+++ b/R/write_xlsx.R
@@ -58,6 +58,11 @@ write_xlsx <- function(x, path = tempfile(fileext = ".xlsx"), col_names = TRUE,
   }
   stopifnot(is.character(path) && length(path))
   path <- normalizePath(path, mustWork = FALSE)
+  # Excel has no concept of a time zone, so decide once, for the whole workbook,
+  # how POSIXct values are written (see .resolve_timezones()).
+  tz_res <- .resolve_timezones(dfs, props)
+  dfs <- tz_res$dfs
+  props <- tz_res$props
   # Resolve everything into one deduplicated workbook format table: the header
   # format, each general cell's effective format, and each sheet's column/row
   # plan -- all cascaded over the workbook default_format.
@@ -71,6 +76,104 @@ write_xlsx <- function(x, path = tempfile(fileext = ".xlsx"), col_names = TRUE,
   ret <- .Call(C_write_data_frame_list, dfs, path, col_names, format_headers,
                use_zip64, reg$table, sheets, header_id, .properties_payload(props))
   invisible(ret)
+}
+
+# =============================================================================
+# Time zones
+# =============================================================================
+#
+# Excel stores a datetime as a naive serial number: it has no time zone.  Rather
+# than silently converting every POSIXct to UTC, writexl decides per workbook:
+#
+#   * all POSIXct values share one time zone -> drop the zone and write local
+#     wall-clock time (2025-12-01 01:00 in Perth is written as 01:00), and drop
+#     the " UTC" suffix from the default datetime format so nothing is mislabelled;
+#   * the time zones differ -> convert everything to UTC and warn, since no
+#     single wall clock can represent them all.
+#
+# The survey covers plain POSIXct columns and POSIXct values inside
+# xl_cell_general cells.
+
+# The time zone of a POSIXct, with NULL/"" (meaning local time) resolved to the
+# session zone so that an unset zone and an explicit local zone compare equal.
+.tzone_of <- function(x){
+  tz <- attr(x, "tzone", exact = TRUE)
+  if(is.null(tz) || !length(tz) || !nzchar(tz[1])){
+    loc <- Sys.timezone()
+    if(is.na(loc)) "" else loc
+  } else {
+    tz[1]
+  }
+}
+
+# Every distinct time zone used by a POSIXct anywhere in the workbook.
+.collect_tzones <- function(dfs){
+  out <- character(0)
+  for(df in dfs){
+    for(col in df){
+      if(inherits(col, "POSIXct")){
+        out <- c(out, .tzone_of(col))
+      } else if(inherits(col, "xl_cell_general")){
+        for(rec in unclass(col))
+          if(inherits(rec$value, "POSIXct"))
+            out <- c(out, .tzone_of(rec$value))
+      }
+    }
+  }
+  unique(out)
+}
+
+# Re-express a POSIXct so that its wall-clock reading is what reaches the cell.
+# The offset is taken per instant, so daylight saving is handled correctly.
+.drop_tzone <- function(x){
+  off <- as.POSIXlt(x, tz = .tzone_of(x))$gmtoff
+  # Some platforms do not report gmtoff; leave the value alone (i.e. UTC) rather
+  # than writing something wrong.
+  if(is.null(off) || any(is.na(off) & !is.na(as.numeric(x))))
+    return(x)
+  off[is.na(off)] <- 0
+  structure(as.numeric(x) + off, class = c("POSIXct", "POSIXt"), tzone = "UTC")
+}
+
+# Apply .drop_tzone() to every POSIXct in a sheet, including inside cell objects.
+.drop_tzones_sheet <- function(df){
+  for(j in seq_along(df)){
+    col <- df[[j]]
+    if(inherits(col, "POSIXct")){
+      df[[j]] <- .drop_tzone(col)
+    } else if(inherits(col, "xl_cell_general")){
+      recs <- unclass(col)
+      touched <- FALSE
+      for(k in seq_along(recs)){
+        if(inherits(recs[[k]]$value, "POSIXct")){
+          recs[[k]]$value <- .drop_tzone(recs[[k]]$value)
+          touched <- TRUE
+        }
+      }
+      if(touched)
+        df[[j]] <- structure(recs, class = class(col))
+    }
+  }
+  df
+}
+
+.resolve_timezones <- function(dfs, props){
+  tzs <- .collect_tzones(dfs)
+  if(length(tzs) > 1L){
+    warning("The workbook contains datetimes in ", length(tzs),
+            " different time zones (", paste(tzs, collapse = ", "),
+            "); all of them were converted to UTC because Excel does not ",
+            "support time zones. Convert them yourself beforehand if you want ",
+            "different behaviour.", call. = FALSE)
+  } else if(length(tzs) == 1L){
+    dfs <- lapply(dfs, .drop_tzones_sheet)
+    # The default format labels datetimes "UTC"; that is no longer true once the
+    # zone has been dropped.  Only replace it if the caller kept the default.
+    if(identical(unclass(props$datetime_format),
+                 unclass(.default_datetime_format())))
+      props$datetime_format <- xl_num_format("yyyy-mm-dd HH:mm:ss")
+  }
+  list(dfs = dfs, props = props)
 }
 
 # Walk a sheet's xl_cell_general columns, register each cell's effective format

--- a/R/write_xlsx.R
+++ b/R/write_xlsx.R
@@ -127,9 +127,12 @@ write_xlsx <- function(x, path = tempfile(fileext = ".xlsx"), col_names = TRUE,
 # The offset is taken per instant, so daylight saving is handled correctly.
 .drop_tzone <- function(x){
   off <- as.POSIXlt(x, tz = .tzone_of(x))$gmtoff
-  # Some platforms do not report gmtoff; leave the value alone (i.e. UTC) rather
-  # than writing something wrong.
-  if(is.null(off) || any(is.na(off) & !is.na(as.numeric(x))))
+  # Not every platform reports gmtoff: older Windows builds of R return NULL or
+  # a zero-length vector.  Fall back to leaving the value alone (i.e. UTC)
+  # rather than writing something wrong -- note the length check, without which
+  # a zero-length offset would recycle to nothing and silently empty the column.
+  if(is.null(off) || length(off) != length(x) ||
+     any(is.na(off) & !is.na(as.numeric(x))))
     return(x)
   off[is.na(off)] <- 0
   structure(as.numeric(x) + off, class = c("POSIXct", "POSIXt"), tzone = "UTC")

--- a/R/xl_workbook.R
+++ b/R/xl_workbook.R
@@ -2,6 +2,11 @@
 # Workbook layer: xl_properties() and xl_workbook()
 # =============================================================================
 
+# The default number format for POSIXct columns.  Shared with
+# .resolve_timezones(), which swaps it out when the time zone is dropped, so
+# the two definitions cannot drift apart.
+.default_datetime_format <- function() xl_num_format("yyyy-mm-dd HH:mm:ss UTC")
+
 #' Workbook properties, defaults, and metadata
 #'
 #' @description
@@ -38,6 +43,13 @@
 #'   `POSIXct` columns.
 #' @param header_row_height Height (in points) of the header row.
 #' @return An `xl_properties` object.
+#' @section Time zones:
+#' Excel has no concept of a time zone.  When every `POSIXct` in the workbook
+#' shares one time zone, writexl drops the zone and writes local wall-clock
+#' time, and the default `datetime_format` loses its `" UTC"` suffix so that
+#' nothing is mislabelled.  When the time zones differ, all datetimes are
+#' converted to UTC with a warning.  Supplying your own `datetime_format`
+#' overrides the label in either case.
 #' @family writexl
 #' @seealso [xl_workbook], [write_xlsx]
 #' @export
@@ -56,7 +68,7 @@ xl_properties <- function(title = NA, subject = NA, author = NA, manager = NA,
                           hyperlink_format = xl_font(color = "blue",
                                                      underline = "single"),
                           date_format      = xl_num_format("yyyy-mm-dd"),
-                          datetime_format  = xl_num_format("yyyy-mm-dd HH:mm:ss UTC"),
+                          datetime_format  = .default_datetime_format(),
                           date_col_width = 20, datetime_col_width = 20,
                           header_row_height = 15) {
   fmts <- list(default_format = default_format, header_format = header_format,

--- a/man/xl_properties.Rd
+++ b/man/xl_properties.Rd
@@ -23,7 +23,7 @@ xl_properties(
   header_format = xl_font(bold = TRUE) + xl_align(horizontal = "center"),
   hyperlink_format = xl_font(color = "blue", underline = "single"),
   date_format = xl_num_format("yyyy-mm-dd"),
-  datetime_format = xl_num_format("yyyy-mm-dd HH:mm:ss UTC"),
+  datetime_format = .default_datetime_format(),
   date_col_width = 20,
   datetime_col_width = 20,
   header_row_height = 15
@@ -76,6 +76,16 @@ it is merged beneath each cell/column format).  `header_format` styles the
 header row and `hyperlink_format` styles cell hyperlinks; both are also
 cascaded over `default_format`.
 }
+\section{Time zones}{
+
+Excel has no concept of a time zone.  When every `POSIXct` in the workbook
+shares one time zone, writexl drops the zone and writes local wall-clock
+time, and the default `datetime_format` loses its `" UTC"` suffix so that
+nothing is mislabelled.  When the time zones differ, all datetimes are
+converted to UTC with a warning.  Supplying your own `datetime_format`
+overrides the label in either case.
+}
+
 \examples{
 xl_properties(title = "Quarterly report", author = "Finance",
               header_format = xl_font(bold = TRUE, color = "white") +

--- a/tests/testthat/test-performance.R
+++ b/tests/testthat/test-performance.R
@@ -1,8 +1,16 @@
 test_that("Performance is OK", {
   skip_if_not_installed("nycflights13")
-  tmp <- writexl::write_xlsx(nycflights13::flights)
+  flights <- nycflights13::flights
+  tmp <- writexl::write_xlsx(flights)
   out <- readxl::read_xlsx(tmp)
   unlink(tmp)
-  attr(out$time_hour, 'tzone') <- attr(nycflights13::flights$time_hour, 'tzone')
-  expect_equal(out, nycflights13::flights)
+  # Excel has no time zones. Every datetime here shares one zone, so writexl
+  # writes local wall-clock time rather than the UTC instant (see the time-zone
+  # tests in test-types.R). Shift back to recover the instant; the offset is
+  # per value because this column spans both EST and EDT.
+  out$time_hour <- out$time_hour - as.POSIXlt(flights$time_hour)$gmtoff
+  attr(out$time_hour, 'tzone') <- attr(flights$time_hour, 'tzone')
+  # max_diffs caps the report: testthat uses max_diffs = Inf on CI, so a
+  # mismatch in this 336k-row frame would otherwise print one line per row.
+  expect_equal(out, flights, max_diffs = 10)
 })

--- a/tests/testthat/test-types.R
+++ b/tests/testthat/test-types.R
@@ -12,6 +12,10 @@ test_that("Types roundtrip properly",{
   input <- data.frame(num = num, int = int, bigint = bigint, str = str, time = time, stringsAsFactors = FALSE)
   expect_warning(output <- roundtrip(input), "int64")
   output$bigint <- bit64::as.integer64(output$bigint)
+  # Excel has no time zones. Every datetime here shares one zone, so writexl
+  # writes local wall-clock time rather than the UTC instant (see the time-zone
+  # tests below); shift back by the UTC offset to recover the instant.
+  output$time <- output$time - as.POSIXlt(time)$gmtoff
   attr(output$time, 'tzone') <- attr(time, 'tzone')
   expect_equal(input, as.data.frame(output))
 })
@@ -101,4 +105,91 @@ test_that("Writing formulas", {
 
   # currently readxl does not support formulas so inspect manually
   expect_true(file.exists(write_xlsx(df)))
+})
+
+# ── POSIXct time zones (Excel stores naive datetimes) ─────────────────────────
+
+# The Excel serial for a naive wall clock, independent of writexl's own maths.
+expected_serial <- function(wall_clock) {
+  25569 + as.numeric(as.POSIXct(wall_clock, tz = "UTC")) / 86400
+}
+datetime_format_of <- function(path) {
+  xml <- xlsx_part(path, "xl/styles.xml", raw = TRUE)
+  if (grepl("HH:mm:ss UTC", xml, fixed = TRUE)) "utc-labelled" else "unlabelled"
+}
+
+test_that("a single time zone is dropped, writing local wall-clock time", {
+  # the reproducer from the issue: Perth 01:00 must not become 17:00 UTC
+  df <- data.frame(dt = as.POSIXct("2025-12-01 01:00:00", tz = "Australia/Perth"))
+  path <- write_tmp(df)
+  expect_equal(sheet_serials(path)[["A2"]],
+               expected_serial("2025-12-01 01:00:00"))
+  # and the default format must no longer claim the value is UTC
+  expect_equal(datetime_format_of(path), "unlabelled")
+})
+
+test_that("dropping a time zone is daylight-saving correct", {
+  # both instants read 12:00 locally despite different UTC offsets
+  df <- data.frame(dt = as.POSIXct(c("2025-01-15 12:00:00", "2025-07-15 12:00:00"),
+                                   tz = "America/New_York"))
+  s <- sheet_serials(write_tmp(df))
+  expect_equal(s[["A2"]], expected_serial("2025-01-15 12:00:00"))
+  expect_equal(s[["A3"]], expected_serial("2025-07-15 12:00:00"))
+})
+
+test_that("an all-UTC workbook is unchanged in value", {
+  df <- data.frame(dt = as.POSIXct("2020-06-01 12:00:00", tz = "UTC"))
+  expect_equal(sheet_serials(write_tmp(df))[["A2"]],
+               expected_serial("2020-06-01 12:00:00"))
+})
+
+test_that("differing time zones warn and are converted to UTC", {
+  df <- data.frame(a = as.POSIXct("2025-12-01 01:00:00", tz = "Australia/Perth"))
+  df$b <- as.POSIXct("2025-12-01 01:00:00", tz = "UTC")
+  expect_warning(path <- write_tmp(df), "different time zones")
+  expect_warning(write_tmp(df), "converted to UTC")
+  s <- sheet_serials(path)
+  expect_equal(s[["A2"]], expected_serial("2025-11-30 17:00:00"))  # Perth -> UTC
+  expect_equal(s[["B2"]], expected_serial("2025-12-01 01:00:00"))
+  # here the UTC label is accurate, so it is kept
+  expect_equal(datetime_format_of(path), "utc-labelled")
+})
+
+test_that("the time zone survey includes POSIXct inside cell objects", {
+  df <- data.frame(a = as.POSIXct("2025-12-01 01:00:00", tz = "Australia/Perth"))
+  df$b <- xl_cell_general(value = as.POSIXct("2025-12-01 01:00:00", tz = "UTC"))
+  expect_warning(write_tmp(df), "different time zones")
+  # a cell object sharing the column's zone must NOT warn, and is shifted too
+  df2 <- data.frame(a = as.POSIXct("2025-12-01 01:00:00", tz = "Australia/Perth"))
+  df2$b <- xl_cell_general(value = as.POSIXct("2025-12-01 03:00:00", tz = "Australia/Perth"))
+  expect_no_warning(path <- write_tmp(df2))
+  s <- sheet_serials(path)
+  expect_equal(s[["A2"]], expected_serial("2025-12-01 01:00:00"))
+  expect_equal(s[["B2"]], expected_serial("2025-12-01 03:00:00"))
+})
+
+test_that("time zones are surveyed across every sheet, not per sheet", {
+  s1 <- data.frame(a = as.POSIXct("2025-12-01 01:00:00", tz = "Australia/Perth"))
+  s2 <- data.frame(a = as.POSIXct("2025-12-01 01:00:00", tz = "UTC"))
+  expect_warning(write_tmp(list(one = s1, two = s2)), "different time zones")
+})
+
+test_that("a supplied datetime_format is never overridden", {
+  df <- data.frame(dt = as.POSIXct("2025-12-01 01:00:00", tz = "Australia/Perth"))
+  wb <- xl_workbook(df, properties = xl_properties(
+    datetime_format = xl_num_format("yyyy/mm/dd hh:mm")))
+  expect_match(xlsx_part(write_tmp(wb), "xl/styles.xml", raw = TRUE),
+               "yyyy/mm/dd hh:mm", fixed = TRUE)
+})
+
+test_that("workbooks without POSIXct are untouched", {
+  expect_no_warning(write_tmp(data.frame(x = 1:3, d = as.Date("2020-01-01") + 0:2)))
+})
+
+test_that("NA datetimes survive the time zone pass", {
+  df <- data.frame(dt = as.POSIXct(c("2025-12-01 01:00:00", NA), tz = "Australia/Perth"))
+  path <- write_tmp(df)
+  s <- sheet_serials(path)
+  expect_equal(s[["A2"]], expected_serial("2025-12-01 01:00:00"))
+  expect_false("A3" %in% names(s))     # NA stays an empty cell
 })

--- a/tests/testthat/test-types.R
+++ b/tests/testthat/test-types.R
@@ -7,15 +7,14 @@ test_that("Types roundtrip properly",{
   num <- c(NA_real_, pi, 1.2345e80)
   int <- c(NA_integer_, 0L, -100L)
   str <- c(NA_character_, "foo", kremlin) #note empty strings don't work yet
-  time <- Sys.time() + 1:3
+  # The zone is set explicitly: writexl drops a single shared time zone and
+  # writes local wall-clock time, so pinning this column to UTC (offset 0) keeps
+  # this test about type round-tripping. Time zones are covered separately below.
+  time <- structure(Sys.time() + 1:3, tzone = "UTC")
   bigint <- bit64::as.integer64(.Machine$integer.max) ^ c(0,1,1.5)
   input <- data.frame(num = num, int = int, bigint = bigint, str = str, time = time, stringsAsFactors = FALSE)
   expect_warning(output <- roundtrip(input), "int64")
   output$bigint <- bit64::as.integer64(output$bigint)
-  # Excel has no time zones. Every datetime here shares one zone, so writexl
-  # writes local wall-clock time rather than the UTC instant (see the time-zone
-  # tests below); shift back by the UTC offset to recover the instant.
-  output$time <- output$time - as.POSIXlt(time)$gmtoff
   attr(output$time, 'tzone') <- attr(time, 'tzone')
   expect_equal(input, as.data.frame(output))
 })
@@ -234,4 +233,16 @@ test_that("NA datetimes survive the time zone pass", {
   s <- sheet_serials(path)
   expect_equal(s[["A2"]], expected_serial("2025-12-01 01:00:00"))
   expect_false("A3" %in% names(s))     # NA stays an empty cell
+})
+
+test_that("dropping a time zone preserves length and NA positions", {
+  # A platform that cannot report a UTC offset must fall back to leaving the
+  # value alone. Without a length check a zero-length offset would recycle to
+  # nothing and silently empty the whole column, so pin the invariant.
+  x <- as.POSIXct(c("2025-01-01 10:00:00", NA, "2025-07-01 10:00:00"),
+                  tz = "America/New_York")
+  y <- .drop_tzone(x)
+  expect_length(y, length(x))
+  expect_equal(is.na(y), is.na(x))
+  expect_length(.drop_tzone(as.POSIXct(character(0), tz = "UTC")), 0L)
 })


### PR DESCRIPTION
Excel stores datetimes as naive serial numbers, with no time zone, so writexl was converting every POSIXct to the UTC instant: a value of 01:00 in Australia/Perth appeared in Excel as the previous day at 17:00, with no warning.

Decide once per workbook instead:

* if every datetime shares one time zone, drop the zone and write local wall-clock time, so 01:00 in Perth is written as 01:00. The shift uses the UTC offset of each individual value, so daylight saving is handled correctly. The default datetime_format also loses its " UTC" suffix, which would otherwise mislabel the value;
* if the time zones differ, convert everything to UTC as before and warn, since no single wall clock can represent them all.

The survey covers plain POSIXct columns and POSIXct values inside xl_cell_general cells, across every sheet, because the choice is workbook-wide. A caller-supplied datetime_format is never overridden. Platforms that do not report a UTC offset fall back to the old UTC behaviour rather than writing something wrong.

The default datetime format is now built by one internal helper shared with the time zone logic, so the two cannot drift apart.

The existing "Types roundtrip properly" test compared instants, which encoded the old behaviour; it now shifts by the UTC offset before comparing. New tests cover the reported case, daylight saving, an all-UTC workbook, differing zones (warning plus UTC), cell objects, multiple sheets, a supplied datetime_format, workbooks without datetimes, and NA handling. Serials are asserted straight from the sheet XML so readxl cannot mask a writer bug.

Fix #105