### PR TITLE
Phase 0: range resolver, sheet overlay stage, constant-memory control

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,5 +1,6 @@
 ^.*\.Rproj$
 ^\.Rproj\.user$
+^\.git$
 ^src/.*\.a$
 ^src/.*\.o$
 ^README.md$

--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -5,5 +5,5 @@
 ^src/.*\.o$
 ^README.md$
 ^\.github$
-^cran-comments\\.md$
+^cran-comments\.md$
 ^codecov\.yml$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,7 +21,7 @@ Suggests:
     spelling,
     readxl,
     nycflights13,
-    testthat (>= 3.0.0),
+    testthat (>= 3.2.0),
     xml2,
     bit64,
     knitr,

--- a/NEWS.md
+++ b/NEWS.md
@@ -97,5 +97,7 @@
   constant-memory mode). The autofilter is its first user.
 
 * Whether the workbook is written in the libxlsxwriter constant-memory mode is
-  now resolved rather than hard-coded. It still always resolves to "on"; no
-  feature yet requires it off.
+  now resolved from the features the workbook actually uses, rather than being
+  hard-coded. It still always resolves to "on"; no feature yet requires it off.
+  The `writexl.constant_memory` option that briefly existed to override this has
+  been removed — the mode is not a user setting.

--- a/NEWS.md
+++ b/NEWS.md
@@ -85,3 +85,17 @@
 * The header, hyperlink, and date/time formats that were previously hard-coded
   in C are now supplied from R as ordinary formats, so their defaults live in
   `xl_properties()` and can be overridden.
+
+* All range addressing now goes through one resolver, which also accepts
+  absolute references and whole-column / whole-row forms. As a result
+  `xl_sheet(freeze =)` additionally accepts `"$A$2"`, and
+  `xl_sheet(autofilter =)` additionally accepts `"$A$1:$D$51"`, `"B:D"` and
+  `"2:10"`; every previously accepted spelling behaves exactly as before.
+
+* Range-scoped worksheet features are applied through a single sheet-overlay
+  stage that runs before rows are written (a requirement of the libxlsxwriter
+  constant-memory mode). The autofilter is its first user.
+
+* Whether the workbook is written in the libxlsxwriter constant-memory mode is
+  now resolved rather than hard-coded. It still always resolves to "on"; no
+  feature yet requires it off.

--- a/R/write_xlsx.R
+++ b/R/write_xlsx.R
@@ -73,8 +73,10 @@ write_xlsx <- function(x, path = tempfile(fileext = ".xlsx"), col_names = TRUE,
   dfs <- lapply(dfs, .resolve_sheet_formats, reg = reg, props = props)
   sheets <- Map(function(el, df) .resolve_sheet_plan(el, df, reg, header_offset, props),
                 elems, dfs)
+  cm <- .resolve_constant_memory(elems, props)
   ret <- .Call(C_write_data_frame_list, dfs, path, col_names, format_headers,
-               use_zip64, reg$table, sheets, header_id, .properties_payload(props))
+               use_zip64, reg$table, sheets, header_id,
+               .properties_payload(props, cm$on))
   invisible(ret)
 }
 

--- a/R/xl_cell_general.R
+++ b/R/xl_cell_general.R
@@ -82,16 +82,16 @@
 xl_cell_general <- function(value = NULL, formula = NULL, hyperlink = NULL,
                             format = NULL, comment = NULL) {
 
-  # 0a. Require at least one content argument --------------------------------
+  # Require at least one content argument -------------------------------------
   if (is.null(value) && is.null(formula) && is.null(hyperlink) &&
       is.null(comment))
     stop("At least one of 'value', 'formula', 'hyperlink', or 'comment' must ",
          "be provided. Use value = NA for an explicit empty cell.", call. = FALSE)
 
-  # 0aa. Reject values writexl cannot write.  Uses the same predicate as the
-  #      column-level check in normalize_df(), so an unsupported type cannot
-  #      slip in by being wrapped in a cell object.  NULL and NA are allowed:
-  #      both mean "blank cell".
+  # Reject values writexl cannot write ----------------------------------------
+  # Uses the same predicate as the column-level check in normalize_df(), so an
+  # unsupported type cannot slip in by being wrapped in a cell object.  NULL
+  # and NA are allowed: both mean "blank cell".
   if (!is.null(value)) {
     vals <- if (is.list(value)) value else list(value)
     keep <- !vapply(vals, is.null, logical(1))
@@ -110,13 +110,14 @@ xl_cell_general <- function(value = NULL, formula = NULL, hyperlink = NULL,
     }
   }
 
-  # 0b. Pre-normalise hyperlink: a named list with 'url' is a single hyperlink
-  #     spec, not a list of multiple hyperlinks.  Wrap it so length() = 1.
+  # Pre-normalise the hyperlink argument --------------------------------------
+  # A named list with a 'url' element is a single hyperlink spec, not a list of
+  # multiple hyperlinks.  Wrap it so length() = 1.
   if (is.list(hyperlink) && !is.null(hyperlink[["url"]])) {
     hyperlink <- list(hyperlink)
   }
 
-  # 1. Determine output length n -------------------------------------------
+  # Determine the output length n ---------------------------------------------
   # A single xl_comment counts as one comment (not its number of fields).
   comment_n <- if (is.null(comment)) 0L
                else if (is_xl_comment(comment)) 1L
@@ -128,14 +129,14 @@ xl_cell_general <- function(value = NULL, formula = NULL, hyperlink = NULL,
     comment_n
   ))
 
-  # 2. Normalise value to a list of length n --------------------------------
+  # Normalise value to a list of length n -------------------------------------
   value_list <- if (is.null(value)) {
     rep(list(NA), n)
   } else {
     rep_len(if (is.list(value)) value else as.list(value), n)
   }
 
-  # 3. Normalise formula to a character vector of length n ------------------
+  # Normalise formula to a character vector of length n -----------------------
   formula_vec <- if (is.null(formula)) {
     rep(NA_character_, n)
   } else {
@@ -146,7 +147,7 @@ xl_cell_general <- function(value = NULL, formula = NULL, hyperlink = NULL,
     rep_len(formula, n)
   }
 
-  # 4. Normalise hyperlink to a list of length n ----------------------------
+  # Normalise hyperlink to a list of length n ---------------------------------
   hyperlink_list <- if (is.null(hyperlink)) {
     rep(list(NA), n)
   } else {
@@ -171,7 +172,7 @@ xl_cell_general <- function(value = NULL, formula = NULL, hyperlink = NULL,
     rep_len(h, n)
   }
 
-  # 5. Normalise format to a list of length n -------------------------------
+  # Normalise format to a list of length n ------------------------------------
   format_list <- if (is.null(format)) {
     vector("list", n)
   } else if (is_xl_format(format)) {
@@ -187,7 +188,7 @@ xl_cell_general <- function(value = NULL, formula = NULL, hyperlink = NULL,
          call. = FALSE)
   }
 
-  # 5b. Normalise comment to a list of length n -----------------------------
+  # Normalise comment to a list of length n -----------------------------------
   # Each element is NULL (no comment) or a C-ready comment payload.  A
   # character vector gives per-cell text with default options; a single
   # xl_comment recycles to every cell; a list mixes strings/xl_comment/NA.
@@ -202,7 +203,7 @@ xl_cell_general <- function(value = NULL, formula = NULL, hyperlink = NULL,
          "strings/xl_comment objects", call. = FALSE)
   }
 
-  # 6. Build per-cell records -----------------------------------------------
+  # Build the per-cell records ------------------------------------------------
   cells <- lapply(seq_len(n), function(i) {
     list(
       value     = value_list[[i]],

--- a/R/xl_range.R
+++ b/R/xl_range.R
@@ -1,0 +1,253 @@
+# =============================================================================
+# Range addressing: one resolver for every range-scoped worksheet feature
+# =============================================================================
+#
+# `.xl_resolve_range()` is the single place where a user-supplied range is
+# turned into the 0-based `c(first_row, first_col, last_row, last_col)` quad
+# that C consumes.  Everything range-scoped goes through it -- the autofilter
+# today, and merged cells / data validation / conditional formats / images /
+# charts / tables as they arrive -- so there is exactly one set of accepted
+# spellings and one set of error messages.
+#
+# Two spellings are accepted:
+#
+#   * an A1-style string:
+#       "A1:D51"        a rectangle
+#       "A2"            a single cell (a zero-span rectangle)
+#       "$A$1:$D$51"    absolute references ($ is ignored)
+#       "B:D"           whole columns, spanning the sheet's used rows
+#       "2:10"          whole rows, spanning the sheet's used columns
+#   * a data-frame-relative spec, `list(rows = , cols = )`, where `cols` names
+#     or indexes columns of the sheet's data frame and `rows` gives 1-based
+#     *data* row indices (row 1 is the first data row, ignoring the header).
+#
+# The header offset is applied here, so C never has to know whether a header
+# row was written.
+# -----------------------------------------------------------------------------
+
+# The xlsx grid limits (mirroring LXW_ROW_MAX / LXW_COL_MAX in libxlsxwriter).
+.XLSX_MAX_ROWS <- 1048576L
+.XLSX_MAX_COLS <- 16384L
+
+# A1 notation, with the `$` of an absolute reference optional and ignored.
+.RE_CELL_REF <- "^[$]?([A-Za-z]{1,3})[$]?([0-9]+)$"
+.RE_COL_REF  <- "^[$]?([A-Za-z]{1,3})$"
+.RE_ROW_REF  <- "^[$]?([0-9]+)$"
+
+# Convert column letters ("A", "AB") to a 0-based column index.
+.col_letters_to_index <- function(letters_str) {
+  chars <- utf8ToInt(toupper(letters_str)) - utf8ToInt("A") + 1L
+  idx <- 0L
+  for (v in chars) idx <- idx * 26L + v
+  idx - 1L
+}
+
+# Validate a 1-based sheet row number and return it 0-based.
+.check_row_number <- function(n, arg) {
+  n <- suppressWarnings(as.numeric(n))
+  if (is.na(n) || n < 1 || n > .XLSX_MAX_ROWS)
+    stop(sprintf("`%s` row must be between 1 and %d", arg, .XLSX_MAX_ROWS),
+         call. = FALSE)
+  as.integer(n) - 1L
+}
+
+# Validate an already 0-based column index.
+.check_col_index <- function(i, arg) {
+  if (is.na(i) || i < 0L || i >= .XLSX_MAX_COLS)
+    stop(sprintf("`%s` column is outside the xlsx grid (maximum column is XFD)",
+                 arg), call. = FALSE)
+  as.integer(i)
+}
+
+# Parse one A1-style cell reference ("A2", "$A$2") to 0-based c(row, col).
+.parse_cell_ref <- function(s, arg) {
+  m <- regmatches(s, regexec(.RE_CELL_REF, s))[[1]]
+  if (length(m) != 3L)
+    stop(sprintf('`%s` must be a cell reference like "A2"', arg), call. = FALSE)
+  c(.check_row_number(m[3L], arg),
+    .check_col_index(.col_letters_to_index(m[2L]), arg))
+}
+
+# The rows a whole-column reference ("B:D") spans: the sheet's used rows when a
+# data frame is available, otherwise the whole grid.
+.sheet_row_extent <- function(df, header_offset, arg) {
+  if (is.null(df)) return(c(0L, .XLSX_MAX_ROWS - 1L))
+  last <- as.integer(header_offset) + nrow(df) - 1L
+  if (last < 0L)
+    stop(sprintf("`%s` covers no rows: the sheet is empty", arg), call. = FALSE)
+  c(0L, as.integer(last))
+}
+
+# The columns a whole-row reference ("2:10") spans.
+.sheet_col_extent <- function(df, arg) {
+  if (is.null(df)) return(c(0L, .XLSX_MAX_COLS - 1L))
+  if (length(df) < 1L)
+    stop(sprintf("`%s` covers no columns: the sheet has no columns", arg),
+         call. = FALSE)
+  c(0L, as.integer(length(df) - 1L))
+}
+
+# Reject an inverted or off-grid quad.  A zero-span range (a single cell) is
+# legitimate and passes.
+.check_range_span <- function(v, arg) {
+  # Unreachable from today's callers -- every path into here has already been
+  # through .check_row_number() / .check_col_index(), which reject anything
+  # below the top-left cell.  Kept as a guard for the kinds still to come, so a
+  # new producer of a quad cannot leak a negative index into C.
+  # nocov start
+  if (v[1L] < 0L || v[2L] < 0L)
+    stop(sprintf("`%s` range starts before the top-left cell", arg),
+         call. = FALSE)
+  # nocov end
+  if (v[3L] < v[1L] || v[4L] < v[2L])
+    stop(sprintf(paste0("`%s` range is inverted: the last cell must not come ",
+                        "before the first"), arg), call. = FALSE)
+  as.integer(v)
+}
+
+# Resolve an A1-style range string.
+.resolve_range_string <- function(rng, arg, df, header_offset, allow_cell) {
+  malformed <- function()
+    stop(sprintf('`%s` range must look like "A1:D51" (got "%s")', arg, rng),
+         call. = FALSE)
+  has_colon <- grepl(":", rng, fixed = TRUE)
+  parts <- strsplit(rng, ":", fixed = TRUE)[[1L]]
+  if (!has_colon) {
+    # A bare cell is a zero-span range, but only where one makes sense.
+    if (!allow_cell || !grepl(.RE_CELL_REF, parts[1L])) malformed()
+    rc <- .parse_cell_ref(parts[1L], arg)
+    return(c(rc[1L], rc[2L], rc[1L], rc[2L]))
+  }
+  if (length(parts) != 2L || !all(nzchar(parts))) malformed()
+  a <- parts[1L]
+  b <- parts[2L]
+  if (grepl(.RE_CELL_REF, a) && grepl(.RE_CELL_REF, b)) {
+    ra <- .parse_cell_ref(a, arg)
+    rb <- .parse_cell_ref(b, arg)
+    return(.check_range_span(c(ra[1L], ra[2L], rb[1L], rb[2L]), arg))
+  }
+  if (grepl(.RE_COL_REF, a) && grepl(.RE_COL_REF, b)) {
+    ext <- .sheet_row_extent(df, header_offset, arg)
+    return(.check_range_span(c(
+      ext[1L], .check_col_index(.col_letters_to_index(sub("^[$]", "", a)), arg),
+      ext[2L], .check_col_index(.col_letters_to_index(sub("^[$]", "", b)), arg)
+    ), arg))
+  }
+  if (grepl(.RE_ROW_REF, a) && grepl(.RE_ROW_REF, b)) {
+    ext <- .sheet_col_extent(df, arg)
+    return(.check_range_span(c(
+      .check_row_number(sub("^[$]", "", a), arg), ext[1L],
+      .check_row_number(sub("^[$]", "", b), arg), ext[2L]
+    ), arg))
+  }
+  malformed()
+}
+
+# The elements a data-frame-relative range spec may carry.
+.RANGE_SPEC_FIELDS <- c("rows", "cols")
+
+# Turn a 1-based index vector into the c(first, last) it spans, refusing a
+# non-contiguous selection: a range is a rectangle, and quietly filling the
+# holes would select cells the caller did not ask for.
+.contiguous_span <- function(idx, arg, what) {
+  u <- sort(unique(as.integer(idx)))
+  if (length(u) > 1L && any(diff(u) != 1L))
+    stop(sprintf("`%s` %s must select a contiguous block", arg, what),
+         call. = FALSE)
+  c(u[1L], u[length(u)])
+}
+
+# Resolve list(rows = , cols = ) against the sheet's data frame.
+.resolve_range_spec <- function(spec, arg, df, header_offset) {
+  nms <- names(spec)
+  if (!length(spec) || is.null(nms) || !all(nzchar(nms)))
+    stop(sprintf("`%s` list must be fully named, e.g. list(rows = 1:3, cols = \"a\")",
+                 arg), call. = FALSE)
+  if (anyDuplicated(nms))
+    stop(sprintf("`%s` list has duplicated element(s): %s", arg,
+                 paste(unique(nms[duplicated(nms)]), collapse = ", ")),
+         call. = FALSE)
+  unknown <- setdiff(nms, .RANGE_SPEC_FIELDS)
+  if (length(unknown))
+    stop(sprintf("unknown `%s` element(s): %s", arg,
+                 paste(unknown, collapse = ", ")), call. = FALSE)
+  if (is.null(df))
+    stop(sprintf("`%s` given as list(rows = , cols = ) needs the sheet's data frame",
+                 arg), call. = FALSE)
+
+  if (is.null(spec$cols)) {
+    if (length(df) < 1L)
+      stop(sprintf("`%s` covers no columns: the sheet has no columns", arg),
+           call. = FALSE)
+    cols <- c(1L, length(df))
+  } else {
+    cols <- .contiguous_span(.resolve_col_index(spec$cols, names(df), arg),
+                             arg, "cols")
+  }
+
+  if (is.null(spec$rows)) {
+    if (nrow(df) < 1L)
+      stop(sprintf("`%s` covers no rows: the sheet has no data rows", arg),
+           call. = FALSE)
+    rows <- c(1L, nrow(df))
+  } else {
+    r <- spec$rows
+    if (!is.numeric(r) || !length(r) || anyNA(r))
+      stop(sprintf("`%s` rows must be a numeric vector of 1-based data-row indices",
+                   arg), call. = FALSE)
+    if (any(r < 1))
+      stop(sprintf("`%s` rows must be positive (1-based data-row indices)", arg),
+           call. = FALSE)
+    rows <- .contiguous_span(r, arg, "rows")
+  }
+
+  first_row <- .check_row_number(rows[1L] + header_offset, arg)
+  last_row  <- .check_row_number(rows[2L] + header_offset, arg)
+  .check_range_span(c(first_row, cols[1L] - 1L, last_row, cols[2L] - 1L), arg)
+}
+
+# Resolve any accepted range spelling to 0-based
+# c(first_row, first_col, last_row, last_col).
+#
+# `arg` names the calling argument in every error message.  `df` and
+# `header_offset` supply the sheet context needed by the data-frame-relative
+# and whole-column/whole-row forms.  `allow_cell = FALSE` rejects a bare cell
+# reference for arguments documented as taking a rectangle.
+.xl_resolve_range <- function(x, arg = "range", df = NULL, header_offset = 1L,
+                              allow_cell = TRUE) {
+  if (is.list(x) && !is.data.frame(x))
+    return(.resolve_range_spec(x, arg, df, header_offset))
+  if (is.character(x) && length(x) == 1L && !is.na(x))
+    return(.resolve_range_string(x, arg, df, header_offset, allow_cell))
+  stop(sprintf(paste0('`%s` must be an Excel range string like "A1:D51" or a ',
+                      "list(rows = , cols = ) spec"), arg), call. = FALSE)
+}
+
+# Parse an Excel range ("A1:D51") into 0-based c(first_row, first_col,
+# last_row, last_col).  A thin wrapper over the shared resolver that keeps the
+# rectangle-only contract of the arguments documented as taking a *range*.
+.parse_range <- function(rng, arg = "autofilter", df = NULL,
+                         header_offset = 1L) {
+  .xl_resolve_range(rng, arg = arg, df = df, header_offset = header_offset,
+                    allow_cell = FALSE)
+}
+
+# Parse a freeze specification into c(freeze_row, freeze_col) (counts), or
+# c(-1, -1) for none.
+#
+# Note the different reading of `list(row =, col =)` here: for `freeze` these
+# are *counts* of rows/columns to freeze, not indices, so only the cell
+# reference form shares the range machinery.
+.parse_freeze <- function(freeze) {
+  if (is.null(freeze) || (length(freeze) == 1L && is.na(freeze)))
+    return(c(-1L, -1L))
+  if (is.list(freeze)) {
+    r <- if (!is.null(freeze$row)) as.integer(freeze$row) else 0L
+    cc <- if (!is.null(freeze$col)) as.integer(freeze$col) else 0L
+    return(c(r, cc))
+  }
+  if (is.character(freeze) && length(freeze) == 1L)
+    return(.parse_cell_ref(freeze, "freeze"))
+  stop('`freeze` must be a cell reference ("A2") or list(row =, col =)',
+       call. = FALSE)
+}

--- a/R/xl_sheet.R
+++ b/R/xl_sheet.R
@@ -226,50 +226,9 @@ print.xl_sheet <- function(x, ...) {
 }
 
 # --- resolution: turn a sheet into the plan C consumes --------------------
-
-# Convert column letters ("A", "AB") to a 0-based column index.
-.col_letters_to_index <- function(letters_str) {
-  chars <- utf8ToInt(toupper(letters_str)) - utf8ToInt("A") + 1L
-  idx <- 0L
-  for (v in chars) idx <- idx * 26L + v
-  idx - 1L
-}
-
-# Parse a freeze specification into c(freeze_row, freeze_col) (counts), or
-# c(-1, -1) for none.
-.parse_freeze <- function(freeze) {
-  if (is.null(freeze) || (length(freeze) == 1L && is.na(freeze)))
-    return(c(-1L, -1L))
-  if (is.list(freeze)) {
-    r <- if (!is.null(freeze$row)) as.integer(freeze$row) else 0L
-    cc <- if (!is.null(freeze$col)) as.integer(freeze$col) else 0L
-    return(c(r, cc))
-  }
-  if (is.character(freeze) && length(freeze) == 1L) {
-    m <- regmatches(freeze, regexec("^([A-Za-z]+)([0-9]+)$", freeze))[[1]]
-    if (length(m) != 3L)
-      stop('`freeze` must be a cell reference like "A2"', call. = FALSE)
-    return(c(as.integer(m[3L]) - 1L, .col_letters_to_index(m[2L])))
-  }
-  stop('`freeze` must be a cell reference ("A2") or list(row =, col =)',
-       call. = FALSE)
-}
-
-# Parse an Excel range ("A1:D51") into 0-based c(first_row, first_col,
-# last_row, last_col).
-.parse_range <- function(rng) {
-  parts <- strsplit(rng, ":", fixed = TRUE)[[1]]
-  cell <- function(s) {
-    m <- regmatches(s, regexec("^([A-Za-z]+)([0-9]+)$", s))[[1]]
-    if (length(m) != 3L)
-      stop('`autofilter` range must look like "A1:D51"', call. = FALSE)
-    c(as.integer(m[3L]) - 1L, .col_letters_to_index(m[2L]))
-  }
-  if (length(parts) != 2L)
-    stop('`autofilter` range must look like "A1:D51"', call. = FALSE)
-  a <- cell(parts[1L]); b <- cell(parts[2L])
-  c(a[1L], a[2L], b[1L], b[2L])
-}
+#
+# Range parsing (`.parse_range()`, `.parse_freeze()`, and the shared resolver
+# they wrap) lives in R/xl_range.R.
 
 # Build the (flag, password, options) triple C uses for worksheet protection.
 .resolve_protect <- function(protect) {
@@ -330,20 +289,48 @@ print.xl_sheet <- function(x, ...) {
   NA_character_
 }
 
-# Resolve targeted columns (names or positions) to 1-based indices.
-.resolve_col_index <- function(index, colnames) {
+# Resolve targeted columns (names or positions) to 1-based indices.  `arg` names
+# the calling argument in the error messages.
+.resolve_col_index <- function(index, colnames, arg = "cols") {
   if (is.character(index)) {
     idx <- match(index, colnames)
     if (anyNA(idx))
-      stop("unknown column(s): ", paste(index[is.na(idx)], collapse = ", "),
-           call. = FALSE)
+      stop(sprintf("`%s`: unknown column(s): ", arg),
+           paste(index[is.na(idx)], collapse = ", "), call. = FALSE)
     idx
   } else {
     idx <- as.integer(index)
     if (any(idx < 1L | idx > length(colnames)))
-      stop("column index out of range", call. = FALSE)
+      stop(sprintf("`%s`: column index out of range", arg), call. = FALSE)
     idx
   }
+}
+
+# --- sheet overlays -------------------------------------------------------
+#
+# A sheet overlay is a range-scoped worksheet feature applied in one pass after
+# the per-sheet scalar options and *before* the row loop -- required under
+# libxlsxwriter's constant-memory mode, where each row is flushed as it is
+# written.  Each payload is a named list carrying a `kind` string that C
+# dispatches on, so a new feature adds a payload kind rather than a new
+# argument to C_write_data_frame_list().
+#
+# The autofilter is the first (and currently only) kind.  `xl_sheet()` has no
+# public `overlay` argument yet; an `overlay` element set on the sheet object
+# is picked up here so the mechanism is reachable for testing and for the
+# features that will populate it.
+
+# The autofilter payload for an already-resolved 0-based range.
+.overlay_autofilter <- function(range) {
+  list(kind = "autofilter", range = as.integer(range))
+}
+
+# Normalise a single payload or a list of payloads to a list of payloads.
+.as_overlay_list <- function(x) {
+  if (is.null(x)) return(list())
+  if (!is.list(x))
+    stop("`overlay` must be an overlay payload or a list of them", call. = FALSE)
+  if (!is.null(x$kind)) list(x) else x
 }
 
 # Build the per-sheet plan (column/row/scalar options) that C applies.
@@ -374,7 +361,7 @@ print.xl_sheet <- function(x, ...) {
   row_fmt_id <- integer(0); row_hidden <- integer(0); row_level <- integer(0)
   freeze <- c(-1L, -1L)
   gridlines <- -1L; tab_color <- -1L; zoom <- 0L; default_row_height <- NA_real_
-  autofilter <- c(-1L, -1L, -1L, -1L)
+  overlay <- list()
   protect <- list(flag = 0L, password = NA_character_, options = NULL)
   # comment defaults are worksheet-scoped (as in libxlsxwriter); a comment's own
   # author overrides the sheet default
@@ -412,12 +399,15 @@ print.xl_sheet <- function(x, ...) {
     default_row_height <- if (is.na(el$default_row_height)) NA_real_ else as.numeric(el$default_row_height)
     af <- el$autofilter
     if (is.character(af)) {
-      autofilter <- .parse_range(af)
+      overlay <- c(overlay, list(.overlay_autofilter(
+        .parse_range(af, "autofilter", df, header_offset))))
     } else if (isTRUE(af)) {
       last_row <- (nrow(df) - 1L) + header_offset
       if (ncols > 0L && last_row >= 0L)
-        autofilter <- c(0L, 0L, as.integer(last_row), ncols - 1L)
+        overlay <- c(overlay, list(.overlay_autofilter(
+          c(0L, 0L, as.integer(last_row), ncols - 1L))))
     }
+    overlay <- c(overlay, .as_overlay_list(el$overlay))
     protect <- .resolve_protect(el$protect)
     comment_author <- el$comment_author
     show_comments <- isTRUE(el$show_comments)
@@ -441,7 +431,7 @@ print.xl_sheet <- function(x, ...) {
     freeze_row = freeze[1L], freeze_col = freeze[2L],
     gridlines = gridlines, tab_color = tab_color, zoom = zoom,
     default_row_height = default_row_height,
-    autofilter = autofilter, protect = protect$flag,
+    overlay = overlay, protect = protect$flag,
     protect_password = protect$password, protect_options = protect$options,
     comment_author = as.character(comment_author),
     show_comments = as.integer(show_comments)

--- a/R/xl_sheet.R
+++ b/R/xl_sheet.R
@@ -226,9 +226,6 @@ print.xl_sheet <- function(x, ...) {
 }
 
 # --- resolution: turn a sheet into the plan C consumes --------------------
-#
-# Range parsing (`.parse_range()`, `.parse_freeze()`, and the shared resolver
-# they wrap) lives in R/xl_range.R.
 
 # Build the (flag, password, options) triple C uses for worksheet protection.
 .resolve_protect <- function(protect) {

--- a/R/xl_workbook.R
+++ b/R/xl_workbook.R
@@ -183,13 +183,6 @@ print.xl_workbook <- function(x, ...) {
   reasons <- character(0)
   # (future) features that cannot work under row streaming append their reason
   # here, e.g. reasons <- c(reasons, "worksheet tables are not supported ...")
-  override <- getOption("writexl.constant_memory")
-  if (!is.null(override)) {
-    if (!is.logical(override) || length(override) != 1L || is.na(override))
-      stop("option `writexl.constant_memory` must be TRUE or FALSE",
-           call. = FALSE)
-    return(list(on = as.integer(override), reasons = character(0)))
-  }
   list(on = as.integer(!length(reasons)), reasons = reasons)
 }
 

--- a/R/xl_workbook.R
+++ b/R/xl_workbook.R
@@ -163,8 +163,40 @@ print.xl_workbook <- function(x, ...) {
   invisible(x)
 }
 
+# --- constant memory ---------------------------------------------------------
+#
+# libxlsxwriter can write a workbook in "constant memory" mode, streaming each
+# row to disk as soon as it is written.  That keeps memory flat for large
+# exports, which is why writexl uses it, but it constrains what may still be
+# applied once a row has been flushed: `worksheet_add_table()` is rejected
+# outright, and `worksheet_merge_range()` only works within the current row.
+# Data validation, conditional formats, images and charts are unaffected.
+#
+# Nothing writexl writes today needs the mode off, so this always resolves to
+# "on".  It exists as a resolver rather than a constant so a feature that
+# cannot work under row streaming can turn it off *and say why* -- append the
+# reason to `reasons` and the flag follows.
+
+# Resolve the constant-memory flag for a workbook.  Returns the C-side integer
+# flag plus the reasons (if any) the mode had to be turned off.
+.resolve_constant_memory <- function(elems, props) {
+  reasons <- character(0)
+  # (future) features that cannot work under row streaming append their reason
+  # here, e.g. reasons <- c(reasons, "worksheet tables are not supported ...")
+  override <- getOption("writexl.constant_memory")
+  if (!is.null(override)) {
+    if (!is.logical(override) || length(override) != 1L || is.na(override))
+      stop("option `writexl.constant_memory` must be TRUE or FALSE",
+           call. = FALSE)
+    return(list(on = as.integer(override), reasons = character(0)))
+  }
+  list(on = as.integer(!length(reasons)), reasons = reasons)
+}
+
 # Build the C-side document-properties payload from an xl_properties object.
-.properties_payload <- function(props) {
+# `constant_memory` rides along here rather than as another .Call() argument so
+# the C entry point's signature stays put as features are added.
+.properties_payload <- function(props, constant_memory = 1L) {
   meta_keys <- c("title", "subject", "author", "manager", "company",
                  "category", "keywords", "comments", "status", "hyperlink_base")
   out <- list()
@@ -185,6 +217,7 @@ print.xl_workbook <- function(x, ...) {
   }
   out$read_only <- as.integer(isTRUE(props$read_only))
   out$header_row_height <- as.numeric(props$header_row_height)
+  out$constant_memory <- as.integer(constant_memory)
   if (!is.null(props$window_size))
     out$window_size <- as.integer(props$window_size)
   if (!is.null(props$names) && length(props$names))

--- a/src/write_xlsx.c
+++ b/src/write_xlsx.c
@@ -279,16 +279,6 @@ static void apply_sheet_scalars(cell_write_ctx *ctx, SEXP opts){
   if(comment_author) worksheet_set_comments_author(ctx->sheet, comment_author);
   if(opt_scalar_int(opts, "show_comments", 0)) worksheet_show_comments(ctx->sheet);
 
-  /* autofilter: a length-4 range (first_row, first_col, last_row, last_col) */
-  SEXP af = list_get(opts, "autofilter");
-  if(af != R_NilValue && Rf_length(af) >= 4){
-    SEXP afi = PROTECT(Rf_coerceVector(af, INTSXP));
-    int *a = INTEGER(afi);
-    if(a[0] >= 0 && a[2] >= a[0] && a[3] >= a[1])
-      worksheet_autofilter(ctx->sheet, a[0], a[1], a[2], a[3]);
-    UNPROTECT(1);
-  }
-
   /* worksheet protection */
   if(opt_scalar_int(opts, "protect", 0)){
     const char *pw = payload_str(opts, "protect_password");
@@ -316,6 +306,54 @@ static void apply_sheet_scalars(cell_write_ctx *ctx, SEXP opts){
       worksheet_protect(ctx->sheet, pw, &prot);
     }
   }
+}
+
+/* --- Sheet overlays ------------------------------------------------------
+ *
+ * Range-scoped worksheet features (the autofilter today; merged cells, data
+ * validation, conditional formats, images, charts and tables later) are all
+ * applied here, in one pass after the per-sheet scalars and *before* the row
+ * loop: under constant_memory each row is flushed as it is written, so
+ * anything spanning rows has to be declared up front.
+ *
+ * Each payload is a named R list built by .resolve_sheet_plan() carrying a
+ * `kind` string.  A new feature adds a kind here rather than another argument
+ * to C_write_data_frame_list().
+ */
+
+/* Read a length-4 0-based range (first_row, first_col, last_row, last_col). */
+static int overlay_range(SEXP p, const char *key, int *out){
+  SEXP v = list_get(p, key);
+  if(v == R_NilValue || Rf_length(v) < 4) return 0;
+  SEXP iv = PROTECT(Rf_coerceVector(v, INTSXP));
+  for(int k = 0; k < 4; k++) out[k] = INTEGER(iv)[k];
+  UNPROTECT(1);
+  return 1;
+}
+
+static void apply_overlay(cell_write_ctx *ctx, SEXP p){
+  const char *kind = payload_str(p, "kind");
+  bail_if(kind == NULL, "sheet overlay payload is missing a 'kind'");
+  if(strcmp(kind, "autofilter") == 0){
+    int r[4];
+    bail_if(!overlay_range(p, "range", r),
+            "autofilter overlay needs a length-4 range");
+    if(r[0] >= 0 && r[2] >= r[0] && r[3] >= r[1])
+      assert_lxw(worksheet_autofilter(ctx->sheet, (lxw_row_t) r[0], (lxw_col_t) r[1],
+                                      (lxw_row_t) r[2], (lxw_col_t) r[3]));
+  } else {
+    Rf_errorcall(R_NilValue,
+                 "Error in writexl: unknown sheet overlay kind '%s'", kind);
+  }
+}
+
+static void apply_sheet_overlays(cell_write_ctx *ctx, SEXP opts){
+  if(opts == R_NilValue) return;
+  SEXP ov = list_get(opts, "overlay");
+  if(ov == R_NilValue || !Rf_isVectorList(ov)) return;
+  R_xlen_t n = Rf_length(ov);
+  for(R_xlen_t k = 0; k < n; k++)
+    apply_overlay(ctx, VECTOR_ELT(ov, k));
 }
 
 /* --- Individual per-type cell writers ------------------------------------ */
@@ -600,9 +638,11 @@ SEXP C_write_data_frame_list(SEXP df_list, SEXP file, SEXP col_names,
   bail_if(formats != R_NilValue && !Rf_isVectorList(formats), "formats must be a list");
   bail_if(sheets != R_NilValue && !Rf_isVectorList(sheets), "sheets must be a list");
 
-  //create workbook
+  //create workbook.  constant_memory (libxlsxwriter's row-streaming mode) is
+  //resolved on the R side by .resolve_constant_memory() and arrives inside the
+  //properties payload; it defaults to on.
   lxw_workbook_options options = {
-    .constant_memory = 1,
+    .constant_memory = (uint8_t) (opt_scalar_int(properties, "constant_memory", 1) ? 1 : 0),
     .tmpdir = TEMPDIR,
     .use_zip64 = Rf_asLogical(use_zip64)
   };
@@ -691,9 +731,12 @@ SEXP C_write_data_frame_list(SEXP df_list, SEXP file, SEXP col_names,
     cell_write_ctx ctx = {workbook, sheet, fmts, nfmts, fmt_prot,
                           sheet_protected, &warn_unlocked};
 
-    // Apply column geometry/formats and sheet-level options (freeze, etc.)
+    // Apply column geometry/formats and sheet-level options (freeze, etc.),
+    // then the range-scoped overlays.  All of this must precede the row loop
+    // because constant_memory flushes each row as it is written.
     apply_columns(&ctx, opts, cols);
     apply_sheet_scalars(&ctx, opts);
+    apply_sheet_overlays(&ctx, opts);
 
     // Need to iterate by row first for performance
     for (lxw_row_t i = 0; i < rows; i++) {

--- a/tests/testthat/test-format-workbook.R
+++ b/tests/testthat/test-format-workbook.R
@@ -159,18 +159,6 @@ test_that("constant memory resolves to on", {
   expect_equal(.properties_payload(xl_properties(), 0L)$constant_memory, 0L)
 })
 
-test_that("the constant_memory override is honoured and validated", {
-  old <- options(writexl.constant_memory = FALSE)
-  on.exit(options(old), add = TRUE)
-  expect_equal(.resolve_constant_memory(list(), xl_properties())$on, 0L)
-  options(writexl.constant_memory = TRUE)
-  expect_equal(.resolve_constant_memory(list(), xl_properties())$on, 1L)
-  options(writexl.constant_memory = "yes")
-  expect_error(.resolve_constant_memory(list(), xl_properties()), "TRUE or FALSE")
-  options(writexl.constant_memory = NA)
-  expect_error(.resolve_constant_memory(list(), xl_properties()), "TRUE or FALSE")
-})
-
 test_that("workbooks write the same content with constant memory on and off", {
   skip_if_not_installed("readxl")
   df <- data.frame(txt = c("alpha", "beta", "alpha"),
@@ -179,10 +167,17 @@ test_that("workbooks write the same content with constant memory on and off", {
                    when = as.Date("2020-01-01") + 0:2,
                    stringsAsFactors = FALSE)
   on_path <- write_tmp(list(D = xl_sheet(df, autofilter = TRUE, freeze = "A2")))
-  old <- options(writexl.constant_memory = FALSE)
-  on.exit(options(old), add = TRUE)
-  off_path <- write_tmp(list(D = xl_sheet(df, autofilter = TRUE, freeze = "A2")))
-  options(old)
+  # No feature writexl writes today turns the mode off, so drive the off path by
+  # mocking the resolver.  It must stay exercised: the C side and libxlsxwriter
+  # behave differently with row streaming disabled, and a phase that needs the
+  # mode off (worksheet tables, multi-cell array formulas) will rely on it.
+  off_path <- local({
+    local_mocked_bindings(
+      .resolve_constant_memory = function(elems, props)
+        list(on = 0L, reasons = "forced off by test")
+    )
+    write_tmp(list(D = xl_sheet(df, autofilter = TRUE, freeze = "A2")))
+  })
 
   # Content must match; the bytes need not -- with constant memory off, strings
   # go to the shared string table instead of being written inline.

--- a/tests/testthat/test-format-workbook.R
+++ b/tests/testthat/test-format-workbook.R
@@ -148,3 +148,58 @@ test_that("de-hardcoded defaults match the previous behavior (regression)", {
   expect_match(s, "yyyy", fixed = TRUE)            # date number format
   expect_match(s, "FF0000FF", ignore.case = TRUE)  # blue hyperlink font
 })
+
+# --- constant memory --------------------------------------------------------
+
+test_that("constant memory resolves to on", {
+  cm <- .resolve_constant_memory(list(data.frame(a = 1)), xl_properties())
+  expect_equal(cm$on, 1L)
+  expect_equal(cm$reasons, character(0))
+  expect_equal(.properties_payload(xl_properties())$constant_memory, 1L)
+  expect_equal(.properties_payload(xl_properties(), 0L)$constant_memory, 0L)
+})
+
+test_that("the constant_memory override is honoured and validated", {
+  old <- options(writexl.constant_memory = FALSE)
+  on.exit(options(old), add = TRUE)
+  expect_equal(.resolve_constant_memory(list(), xl_properties())$on, 0L)
+  options(writexl.constant_memory = TRUE)
+  expect_equal(.resolve_constant_memory(list(), xl_properties())$on, 1L)
+  options(writexl.constant_memory = "yes")
+  expect_error(.resolve_constant_memory(list(), xl_properties()), "TRUE or FALSE")
+  options(writexl.constant_memory = NA)
+  expect_error(.resolve_constant_memory(list(), xl_properties()), "TRUE or FALSE")
+})
+
+test_that("workbooks write the same content with constant memory on and off", {
+  skip_if_not_installed("readxl")
+  df <- data.frame(txt = c("alpha", "beta", "alpha"),
+                   num = c(1.5, 2, 3),
+                   flag = c(TRUE, FALSE, NA),
+                   when = as.Date("2020-01-01") + 0:2,
+                   stringsAsFactors = FALSE)
+  on_path <- write_tmp(list(D = xl_sheet(df, autofilter = TRUE, freeze = "A2")))
+  old <- options(writexl.constant_memory = FALSE)
+  on.exit(options(old), add = TRUE)
+  off_path <- write_tmp(list(D = xl_sheet(df, autofilter = TRUE, freeze = "A2")))
+  options(old)
+
+  # Content must match; the bytes need not -- with constant memory off, strings
+  # go to the shared string table instead of being written inline.
+  rd_on  <- as.data.frame(readxl::read_xlsx(on_path))
+  rd_off <- as.data.frame(readxl::read_xlsx(off_path))
+  expect_equal(rd_off, rd_on)
+  expect_equal(rd_off$txt, df$txt)
+  expect_equal(as.Date(rd_off$when), df$when)
+
+  # ... and the worksheet features survive either way
+  for (p in c(on_path, off_path)) {
+    w <- xlsx_part(p, "xl/worksheets/sheet1.xml", raw = TRUE)
+    expect_match(w, '<autoFilter ref="A1:D4"')
+    expect_match(w, "<pane")
+  }
+
+  # the storage difference itself, so the off path cannot rot unnoticed
+  expect_null(xlsx_part(on_path, "xl/sharedStrings.xml"))
+  expect_s3_class(xlsx_part(off_path, "xl/sharedStrings.xml"), "xml_document")
+})

--- a/tests/testthat/test-format-worksheet.R
+++ b/tests/testthat/test-format-worksheet.R
@@ -188,3 +188,56 @@ test_that("xl_sheet mixes with plain data frames in one workbook", {
   expect_silent(write_xlsx(wb, tmp))
   expect_equal(readxl::read_xlsx(tmp, sheet = "Plain")$b, 1:2)
 })
+
+# --- sheet overlays ---------------------------------------------------------
+#
+# Range-scoped features are applied through one payload list dispatched on
+# `kind` in C.  The autofilter is the first kind (its own behavior is covered
+# in test-format-protect.R); these tests cover the mechanism itself.
+
+test_that("the autofilter reaches C as an overlay payload", {
+  plan <- .resolve_sheet_plan(xl_sheet(data.frame(a = 1:3), autofilter = TRUE),
+                              data.frame(a = 1:3), .new_format_registry(), 1L,
+                              xl_properties())
+  expect_equal(plan$overlay,
+               list(list(kind = "autofilter", range = c(0L, 0L, 3L, 0L))))
+  expect_null(plan$autofilter)   # the old scalar slot is gone
+})
+
+test_that("a sheet with no range features carries no overlays", {
+  plan <- .resolve_sheet_plan(xl_sheet(data.frame(a = 1:3)), data.frame(a = 1:3),
+                              .new_format_registry(), 1L, xl_properties())
+  expect_equal(plan$overlay, list())
+})
+
+test_that("an overlay set on the sheet is applied", {
+  s <- xl_sheet(data.frame(a = 1:3))
+  s$overlay <- list(kind = "autofilter", range = c(0L, 0L, 3L, 0L))
+  expect_match(sheet_xml(list(D = s)), '<autoFilter ref="A1:A4"')
+})
+
+test_that("an unknown overlay kind is an error, not a silent no-op", {
+  s <- xl_sheet(data.frame(a = 1:3))
+  s$overlay <- list(kind = "bogus")
+  expect_error(write_tmp(list(D = s)), "unknown sheet overlay kind 'bogus'")
+})
+
+test_that("an overlay payload without a kind is an error", {
+  s <- xl_sheet(data.frame(a = 1:3))
+  s$overlay <- list(list(range = c(0L, 0L, 1L, 0L)))
+  expect_error(write_tmp(list(D = s)), "missing a 'kind'")
+})
+
+test_that("an autofilter overlay without a usable range is an error", {
+  s <- xl_sheet(data.frame(a = 1:3))
+  s$overlay <- list(kind = "autofilter", range = 1:2)
+  expect_error(write_tmp(list(D = s)), "length-4 range")
+})
+
+test_that("overlay payload lists are normalised", {
+  one <- list(kind = "autofilter", range = 1:4)
+  expect_equal(.as_overlay_list(NULL), list())
+  expect_equal(.as_overlay_list(one), list(one))
+  expect_equal(.as_overlay_list(list(one, one)), list(one, one))
+  expect_error(.as_overlay_list("x"), "overlay payload")
+})

--- a/tests/testthat/test-xl_range.R
+++ b/tests/testthat/test-xl_range.R
@@ -1,0 +1,159 @@
+# Tests for the shared range resolver in R/xl_range.R.
+
+df3 <- data.frame(a = 1:3, b = 4:6, c = 7:9)
+
+test_that("column letters convert to 0-based indices", {
+  expect_equal(.col_letters_to_index("A"), 0L)
+  expect_equal(.col_letters_to_index("b"), 1L)
+  expect_equal(.col_letters_to_index("Z"), 25L)
+  expect_equal(.col_letters_to_index("AA"), 26L)
+  expect_equal(.col_letters_to_index("XFD"), 16383L)   # the last xlsx column
+})
+
+test_that("cell references parse, including absolute form", {
+  expect_equal(.parse_cell_ref("A1", "x"), c(0L, 0L))
+  expect_equal(.parse_cell_ref("a2", "x"), c(1L, 0L))
+  expect_equal(.parse_cell_ref("D51", "x"), c(50L, 3L))
+  expect_equal(.parse_cell_ref("$D$51", "x"), c(50L, 3L))
+  expect_equal(.parse_cell_ref("$D51", "x"), c(50L, 3L))
+  expect_error(.parse_cell_ref("nonsense", "x"), "cell reference")
+  expect_error(.parse_cell_ref("1A", "x"), "cell reference")
+  expect_error(.parse_cell_ref("", "x"), "cell reference")
+})
+
+test_that("grid limits are enforced on cell references", {
+  expect_error(.parse_cell_ref("A0", "x"), "row must be between 1")
+  expect_error(.parse_cell_ref("A1048577", "x"), "row must be between 1")
+  expect_equal(.parse_cell_ref("XFD1048576", "x"), c(1048575L, 16383L))
+  expect_error(.parse_cell_ref("XFE1", "x"), "outside the xlsx grid")
+})
+
+test_that("A1 rectangles resolve, absolute or not", {
+  expect_equal(.xl_resolve_range("A1:D51", "x"), c(0L, 0L, 50L, 3L))
+  expect_equal(.xl_resolve_range("$A$1:$D$51", "x"), c(0L, 0L, 50L, 3L))
+  expect_equal(.xl_resolve_range("B2:B2", "x"), c(1L, 1L, 1L, 1L))  # zero span
+})
+
+test_that("a bare cell is a zero-span range where one is allowed", {
+  expect_equal(.xl_resolve_range("A2", "x"), c(1L, 0L, 1L, 0L))
+  expect_equal(.xl_resolve_range("$C$4", "x"), c(3L, 2L, 3L, 2L))
+  # ... and is rejected where the argument is documented as taking a rectangle
+  expect_error(.xl_resolve_range("A2", "x", allow_cell = FALSE), "A1:D51")
+})
+
+test_that("whole-column references span the sheet's used rows", {
+  expect_equal(.xl_resolve_range("B:D", "x", df3, 1L), c(0L, 1L, 3L, 3L))
+  expect_equal(.xl_resolve_range("B:D", "x", df3, 0L), c(0L, 1L, 2L, 3L))
+  expect_equal(.xl_resolve_range("$B:$B", "x", df3, 1L), c(0L, 1L, 3L, 1L))
+  # with no data frame in hand, the whole grid
+  expect_equal(.xl_resolve_range("B:D", "x"), c(0L, 1L, 1048575L, 3L))
+})
+
+test_that("whole-row references span the sheet's used columns", {
+  expect_equal(.xl_resolve_range("2:10", "x", df3, 1L), c(1L, 0L, 9L, 2L))
+  expect_equal(.xl_resolve_range("$2:$2", "x", df3, 1L), c(1L, 0L, 1L, 2L))
+  expect_equal(.xl_resolve_range("2:10", "x"), c(1L, 0L, 9L, 16383L))
+})
+
+test_that("malformed range strings are rejected and name the argument", {
+  for (bad in c("A1:", ":", ":B2", "A1::B2", "A1:9", "9:A1", "A1:B", "",
+                "not a range", "A1:B2:C3")) {
+    expect_error(.xl_resolve_range(bad, "merge"), "`merge` range must look like",
+                 fixed = TRUE)
+  }
+})
+
+test_that("non-string, non-list ranges are rejected", {
+  expect_error(.xl_resolve_range(42, "merge"), "`merge` must be an Excel range",
+               fixed = TRUE)
+  expect_error(.xl_resolve_range(NA_character_, "merge"), "must be an Excel range")
+  expect_error(.xl_resolve_range(c("A1:B2", "C1:C2"), "merge"),
+               "must be an Excel range")
+})
+
+test_that("inverted ranges are an error, zero-span ones are not", {
+  expect_error(.xl_resolve_range("D1:A1", "merge"), "inverted")
+  expect_error(.xl_resolve_range("A5:A2", "merge"), "inverted")
+  expect_error(.xl_resolve_range("D:A", "merge", df3, 1L), "inverted")
+  expect_error(.xl_resolve_range("10:2", "merge", df3, 1L), "inverted")
+  expect_equal(.xl_resolve_range("A1:A1", "merge"), c(0L, 0L, 0L, 0L))
+})
+
+test_that("data-frame-relative specs resolve rows and columns", {
+  expect_equal(.xl_resolve_range(list(rows = 1:2, cols = c("a", "b")), "m", df3, 1L),
+               c(1L, 0L, 2L, 1L))
+  expect_equal(.xl_resolve_range(list(rows = 1:2, cols = c("a", "b")), "m", df3, 0L),
+               c(0L, 0L, 1L, 1L))
+  expect_equal(.xl_resolve_range(list(rows = 2, cols = 2), "m", df3, 1L),
+               c(2L, 1L, 2L, 1L))
+  # numeric column positions and unsorted input both work
+  expect_equal(.xl_resolve_range(list(rows = c(3, 2), cols = c(3, 2)), "m", df3, 1L),
+               c(2L, 1L, 3L, 2L))
+})
+
+test_that("an omitted rows/cols element means the whole data block", {
+  expect_equal(.xl_resolve_range(list(cols = "b"), "m", df3, 1L), c(1L, 1L, 3L, 1L))
+  expect_equal(.xl_resolve_range(list(cols = "b"), "m", df3, 0L), c(0L, 1L, 2L, 1L))
+  expect_equal(.xl_resolve_range(list(rows = 1), "m", df3, 1L), c(1L, 0L, 1L, 2L))
+})
+
+test_that("range specs are validated", {
+  expect_error(.xl_resolve_range(list(), "m", df3, 1L), "must be fully named")
+  expect_error(.xl_resolve_range(list(1:2), "m", df3, 1L), "must be fully named")
+  expect_error(.xl_resolve_range(list(rows = 1, rows = 2), "m", df3, 1L),
+               "duplicated element")
+  expect_error(.xl_resolve_range(list(row = 1), "m", df3, 1L),
+               "unknown `m` element", fixed = TRUE)
+  expect_error(.xl_resolve_range(list(cols = "a"), "m"), "needs the sheet's data frame")
+  expect_error(.xl_resolve_range(list(cols = "z"), "m", df3, 1L), "unknown column")
+  expect_error(.xl_resolve_range(list(cols = 9), "m", df3, 1L), "out of range")
+  expect_error(.xl_resolve_range(list(rows = 0), "m", df3, 1L), "must be positive")
+  expect_error(.xl_resolve_range(list(rows = "a"), "m", df3, 1L), "must be a numeric")
+  expect_error(.xl_resolve_range(list(rows = numeric(0)), "m", df3, 1L),
+               "must be a numeric")
+  expect_error(.xl_resolve_range(list(rows = c(1, NA)), "m", df3, 1L),
+               "must be a numeric")
+})
+
+test_that("a range must be a contiguous rectangle", {
+  expect_error(.xl_resolve_range(list(cols = c("a", "c")), "m", df3, 1L),
+               "cols must select a contiguous block")
+  expect_error(.xl_resolve_range(list(rows = c(1, 3)), "m", df3, 1L),
+               "rows must select a contiguous block")
+})
+
+test_that("degenerate sheets are reported, not silently accepted", {
+  empty_rows <- data.frame(a = integer(0), b = integer(0))
+  no_cols <- data.frame(a = 1:2)[, character(0), drop = FALSE]
+  expect_error(.xl_resolve_range(list(cols = "a"), "m", empty_rows, 1L),
+               "covers no rows")
+  expect_error(.xl_resolve_range(list(rows = 1), "m", no_cols, 1L),
+               "covers no columns")
+  expect_error(.xl_resolve_range("1:2", "m", no_cols, 1L), "covers no columns")
+  # with a header row a 0-row sheet still has one usable row
+  expect_equal(.xl_resolve_range("A:A", "m", empty_rows, 1L), c(0L, 0L, 0L, 0L))
+  expect_error(.xl_resolve_range("A:A", "m", empty_rows, 0L), "covers no rows")
+})
+
+test_that("rows beyond the xlsx grid are rejected", {
+  expect_error(.xl_resolve_range(list(rows = 1048576), "m", df3, 1L),
+               "row must be between 1")
+})
+
+test_that(".parse_range keeps its rectangle-only contract", {
+  expect_equal(.parse_range("A1:D51"), c(0L, 0L, 50L, 3L))
+  expect_error(.parse_range("A1"), "`autofilter` range must look like",
+               fixed = TRUE)
+  expect_error(.parse_range("A1:B2", "merge"), NA)
+  expect_error(.parse_range("A1", "merge"), "`merge` range must look like",
+               fixed = TRUE)
+})
+
+test_that("freeze specs reuse the cell-reference parser but keep count semantics", {
+  expect_equal(.parse_freeze("$B$3"), c(2L, 1L))
+  # list(row =, col =) here means counts of frozen rows/columns, not indices
+  expect_equal(.parse_freeze(list(row = 2, col = 1)), c(2L, 1L))
+  expect_equal(.parse_freeze(list(row = 3)), c(3L, 0L))
+  expect_equal(.parse_freeze(list(col = 3)), c(0L, 3L))
+  expect_equal(.parse_freeze(NA_character_), c(-1L, -1L))
+})


### PR DESCRIPTION
Foundation work for the libxlsxwriter API coverage roadmap. No new user-visible
features — this exists to unblock the later phases.

## What's here

**Shared range resolver** (`R/xl_range.R`, new). One implementation of range
parsing, replacing three ad hoc private helpers in `R/xl_sheet.R`. Accepts A1
rectangles (`"A1:D51"`), single cells, absolute refs (`"$A$1:$D$51"`),
whole-column (`"B:D"`) and whole-row (`"2:10"`) forms, and a data-frame-relative
`list(rows =, cols =)` spec with column names. Returns 0-based bounds with
`header_offset` applied. Errors name the calling argument instead of hardcoding
"autofilter", and reject malformed strings, off-grid indices, non-contiguous
selections and inverted ranges.

**Sheet overlay stage.** An `overlay` slot on the per-sheet plan plus
`apply_sheet_overlays()` in `src/write_xlsx.c`, called before the row loop (which
is what constant-memory mode requires). Dispatches on a `kind` field so later
phases add a payload type rather than a function argument; unknown or missing
`kind` errors. Autofilter was migrated onto it as the first consumer, so the
machinery ships with real coverage rather than as unexercised infrastructure.

**Constant-memory control.** `.resolve_constant_memory()` replaces the hardwired
`constant_memory = 1`. It always resolves to on today, with a documented
`reasons` slot for a future phase to populate when a feature can't work under
row streaming. The flag rides inside the existing properties payload, so
`.Call(C_write_data_frame_list, ...)` is still 9 arguments.

**Comment cleanup.** The `# 0a. / # 0aa. / # 0b. / … / # 5b.` markers in
`xl_cell_general()` are replaced with descriptive banners in the file's existing
idiom. Explanatory content preserved; verified comments-only by filtering the
diff.

## Behaviour changes

One, and it's additive: because `freeze` and `autofilter` now share the
resolver, `freeze` accepts `"$A$2"` and `autofilter` accepts absolute refs plus
`"B:D"` / `"2:10"`. Both previously errored, so nothing that worked before
behaves differently. Noted in `NEWS.md`.

## Verification

- Tests: 0 failures, 1 skip (pre-existing `test-limits.R:27`, "On CRAN"). The
  577 pre-existing tests pass **unmodified**.
- `devtools::check()`: 0 errors, 0 warnings, 0 notes (the `.git` note is fixed by
  the `.Rbuildignore` entry in this branch).
- Coverage: `R/xl_sheet.R` and `R/xl_workbook.R` 100%, `R/xl_range.R` 98.4%,
  `src/write_xlsx.c` 98.3%. The one uncovered block is an unreachable guard in
  `.check_range_span()`, marked `# nocov` with the reason.
- `devtools::document()` produces no drift; nothing new is exported.

## Notes for review

- The overlay stage has no public `xl_sheet(overlay =)` argument yet — it's
  reached internally and by tests. Its first public consumer will be Phase 1's
  array formula ranges.
- Constant memory is flippable only via an undocumented
  `getOption("writexl.constant_memory")`, chosen over `local_mocked_bindings()`
  because that needs testthat >= 3.2 while DESCRIPTION requires >= 3.0.0. Worth
  deciding whether that stays or becomes a proper test helper.
- `.resolve_constant_memory(elems, props)` ignores both arguments today, on
  purpose, so a future phase can inspect sheets without touching the call site.