### PR TITLE
Exclude vendored libxlsxwriter from coverage counting

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -7,3 +7,4 @@
 ^\.github$
 ^cran-comments\.md$
 ^codecov\.yml$
+^\.covrignore$

--- a/.covrignore
+++ b/.covrignore
@@ -1,0 +1,5 @@
+# Vendored third-party C code: libxlsxwriter and its bundled dependencies
+# (minizip, md5, tmpfileplus, emyg_dtoa). writexl neither maintains nor
+# tests this code, so it should not count toward writexl's coverage.
+# src/write_xlsx.c is writexl's own C code and is deliberately NOT listed.
+src/libxlsxwriter

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,5 +1,12 @@
 comment: false
 
+# Vendored third-party C code (libxlsxwriter and its bundled dependencies).
+# Also excluded via .covrignore; this is a Codecov-side backstop in case any
+# vendored path still reaches the uploaded report.
+ignore:
+  - "src/libxlsxwriter"
+  - "src/libxlsxwriter/**/*"
+
 coverage:
   status:
     project:


### PR DESCRIPTION
src/libxlsxwriter/ is third-party code (libxlsxwriter 1.2.4 plus its bundled dependencies under third_party/: minizip, md5, tmpfileplus, emyg_dtoa). writexl neither maintains nor tests it, so its lines only dilute the reported coverage percentage.

Add a .covrignore listing src/libxlsxwriter. covr expands a directory entry recursively and appends the result to line_exclusions after gcov results are merged into the coverage object, so this drops the compiled vendored translation units as well as the R-side files.

Also add a matching codecov.yml ignore: entry as a Codecov-side backstop, in case a vendored path reaches the uploaded Cobertura report by a route covr's exclusion machinery does not cover.

src/write_xlsx.c is writexl's own C code and is deliberately not excluded; it remains measured.

Verified locally with the same package_coverage() arguments the test-coverage workflow uses: overall coverage goes from 37.10% (30 libxlsxwriter files measured) to 99.05% (0 measured), while src/write_xlsx.c is still reported at 98.31% over the same 415 lines.

.covrignore is added to .Rbuildignore so it does not ship in the tarball; R CMD check remains at 0 errors / 0 warnings / 0 notes.