### PR TITLE
Ignore R build and check artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,7 @@ src/libxlsxwriter/third_party/minizip/*
 !src/libxlsxwriter/third_party/minizip/ioapi.h
 !src/libxlsxwriter/third_party/minizip/zip.c
 !src/libxlsxwriter/third_party/minizip/zip.h
+*.tar.gz
+*.tgz
+*.Rcheck/
+.Ruserdata


### PR DESCRIPTION
.gitignore covered compiled objects and gcov output but not the products of R CMD build and R CMD check, so a build or check run in the repository root showed up as untracked files.