### PR TITLE
Phase 4: sheet view and navigation

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -29,6 +29,13 @@
   and footers, print area, repeating heading rows/columns, manual page breaks,
   and the print options.
 
+* **Sheet tabs and the opening view** via `xl_sheet()`: which tab is active,
+  selected, hidden or leftmost; the selected cell and scroll position; hiding
+  zero values; right-to-left column order; and split panes alongside the
+  existing frozen panes. The workbook-wide visibility rules (only one active
+  sheet, no hidden-and-active sheet, at least one visible sheet) are checked
+  before writing, naming the sheet at fault.
+
 * `xl_properties(hyperlink_format = NULL)` writes hyperlinks with no styling at
   all, which was previously impossible.
 

--- a/R/sheet_visibility.R
+++ b/R/sheet_visibility.R
@@ -1,0 +1,80 @@
+# =============================================================================
+# Sheet visibility: which tab opens, which are selected, which are hidden
+# =============================================================================
+#
+# These are the only worksheet settings whose rules span the whole workbook, so
+# unlike everything else in the sheet plan they cannot be validated one sheet at
+# a time.  Excel's rules, as documented for worksheet_hide():
+#
+#   * a hidden sheet cannot be activated or selected -- the calls are mutually
+#     exclusive;
+#   * the first sheet is active by default, so it cannot be hidden unless some
+#     other sheet is made active;
+#   * at most one sheet may be active;
+#   * at least one sheet must stay visible, or Excel refuses to open the file.
+#
+# libxlsxwriter enforces none of them: worksheet_hide(), worksheet_activate()
+# and worksheet_select() all return void and simply set a flag.  A bad
+# combination therefore produces a broken workbook with no diagnostic, so the
+# checks live here and name the sheet at fault.
+# -----------------------------------------------------------------------------
+
+# One sheet's visibility settings, with absent ones as NA.
+.sheet_view_flags <- function(el) {
+  if (!inherits(el, "xl_sheet"))
+    return(list(active = NA, selected = NA, visible = NA, first_tab = NA))
+  list(active    = el$active,
+       selected  = el$selected,
+       visible   = el$visible,
+       first_tab = el$first_tab)
+}
+
+# A readable name for a sheet in an error message.
+.sheet_label <- function(nms, i) {
+  if (!is.null(nms) && length(nms) >= i && !is.na(nms[i]) && nzchar(nms[i]))
+    sprintf('"%s"', nms[i])
+  else
+    sprintf("%d", i)
+}
+
+# Validate the workbook-wide visibility rules.  Returns nothing; it exists to
+# fail loudly before anything is written.
+.resolve_sheet_visibility <- function(elems, nms = names(elems)) {
+  n <- length(elems)
+  if (!n) return(invisible(NULL))
+  f <- lapply(elems, .sheet_view_flags)
+  is_set <- function(k, want) vapply(f, function(x) identical(x[[k]], want),
+                                     logical(1))
+
+  hidden   <- is_set("visible", FALSE)
+  active   <- is_set("active", TRUE)
+  selected <- is_set("selected", TRUE)
+
+  # every sheet hidden -> Excel will not open the file
+  if (all(hidden))
+    stop("every sheet is hidden; a workbook needs at least one visible sheet",
+         call. = FALSE)
+
+  # a hidden sheet cannot also be the active or a selected one
+  bad <- which(hidden & (active | selected))
+  if (length(bad))
+    stop(sprintf(paste0("sheet %s is hidden but also marked active/selected; ",
+                        "Excel cannot show a hidden sheet"),
+                 .sheet_label(nms, bad[1L])), call. = FALSE)
+
+  # only one active sheet
+  if (sum(active) > 1L)
+    stop(sprintf("sheets %s are both marked active; only one sheet may be active",
+                 paste(vapply(which(active), function(i) .sheet_label(nms, i),
+                              character(1)), collapse = " and ")),
+         call. = FALSE)
+
+  # the first sheet is active by default, so hiding it needs another active one
+  if (hidden[1L] && !any(active))
+    stop(sprintf(paste0("sheet %s is the first sheet and cannot be hidden ",
+                        "unless another sheet is given active = TRUE, since ",
+                        "Excel opens on the first sheet by default"),
+                 .sheet_label(nms, 1L)), call. = FALSE)
+
+  invisible(NULL)
+}

--- a/R/split_panes.R
+++ b/R/split_panes.R
@@ -1,0 +1,84 @@
+# =============================================================================
+# Split panes: converting a cell reference into libxlsxwriter's units
+# =============================================================================
+#
+# worksheet_split_panes() does not take a row and a column.  Its two arguments
+# are distances, measured in the units Excel uses for row height and column
+# width, and the two units differ from each other:
+#
+#     worksheet_split_panes(worksheet1, 15, 0);    // First row.
+#     worksheet_split_panes(worksheet2, 0,  8.43); // First column.
+#
+# So `vertical` is a number of row-heights and positions the split *between
+# rows*, while `horizontal` is a number of column-widths and positions it
+# between columns.  Passing 1 for "one row" would put the split a fifteenth of
+# the way down the first row, silently.
+#
+# writexl therefore takes a cell reference, as `freeze` does, and converts:
+# the distance above the split is the summed height of the rows before it, and
+# the distance to its left is the summed width of the columns before it.  Those
+# use the sheet's real geometry -- header row height, xl_row_spec() heights,
+# xl_col_spec() widths and auto_colwidth results -- rather than assuming the
+# defaults, so a split lands where it was asked for on a sheet whose rows or
+# columns have been resized.
+#
+# A raw list(vertical =, horizontal =) is still accepted for callers who want
+# to specify the units directly.
+# -----------------------------------------------------------------------------
+
+# Excel's defaults, and the values libxlsxwriter's own examples use.
+.DEFAULT_ROW_HEIGHT <- 15
+.DEFAULT_COL_WIDTH  <- 8.43
+
+# The height of one 0-based sheet row: an explicit xl_row_spec() height, else
+# the sheet default, else Excel's.
+.row_height_at <- function(i, header_offset, props, default_row_height,
+                           row_row, row_height) {
+  k <- which(row_row == i)
+  if (length(k) && !is.na(row_height[k[1L]])) return(row_height[k[1L]])
+  if (header_offset > 0L && i == 0L && !is.null(props$header_row_height))
+    return(as.numeric(props$header_row_height))
+  if (!is.na(default_row_height)) return(as.numeric(default_row_height))
+  .DEFAULT_ROW_HEIGHT
+}
+
+# The width of one 1-based column.
+.col_width_at <- function(j, col_width) {
+  if (j <= length(col_width) && !is.na(col_width[j])) col_width[j]
+  else .DEFAULT_COL_WIDTH
+}
+
+.resolve_split <- function(spec, df, header_offset, props, default_row_height,
+                           row_row, row_height, col_width) {
+  # raw units, for callers who want to place the split exactly
+  if (is.list(spec) &&
+      (!is.null(spec[["vertical"]]) || !is.null(spec[["horizontal"]]))) {
+    bad <- setdiff(names(spec), c("vertical", "horizontal"))
+    if (length(bad))
+      stop("unknown `split` element(s): ", paste(bad, collapse = ", "),
+           call. = FALSE)
+    v <- if (is.null(spec$vertical)) 0 else as.numeric(spec$vertical)
+    h <- if (is.null(spec$horizontal)) 0 else as.numeric(spec$horizontal)
+    if (anyNA(c(v, h)) || any(c(v, h) < 0))
+      stop("`split` units must be non-negative numbers", call. = FALSE)
+    return(c(vertical = v, horizontal = h))
+  }
+
+  q <- .xl_resolve_range(spec, arg = "split", df = df,
+                         header_offset = header_offset, allow_cell = TRUE)
+  n_rows <- q[1L]   # 0-based row index == how many rows sit above the split
+  n_cols <- q[2L]
+
+  vertical <- 0
+  if (n_rows > 0L)
+    vertical <- sum(vapply(seq_len(n_rows) - 1L, .row_height_at, numeric(1),
+                           header_offset = header_offset, props = props,
+                           default_row_height = default_row_height,
+                           row_row = row_row, row_height = row_height))
+  horizontal <- 0
+  if (n_cols > 0L)
+    horizontal <- sum(vapply(seq_len(n_cols), .col_width_at, numeric(1),
+                             col_width = col_width))
+
+  c(vertical = vertical, horizontal = horizontal)
+}

--- a/R/write_xlsx.R
+++ b/R/write_xlsx.R
@@ -47,6 +47,9 @@ write_xlsx <- function(x, path = tempfile(fileext = ".xlsx"), col_names = TRUE,
   dfs <- lapply(elems, function(el) if(inherits(el, "xl_sheet")) el$data else el)
   dfs <- lapply(dfs, normalize_df)
   names(dfs) <- .resolve_sheet_names(names(elems), length(dfs))
+  # tab visibility is the one worksheet setting whose rules span the whole
+  # workbook, so it is checked here rather than per sheet
+  .resolve_sheet_visibility(elems, names(dfs))
   stopifnot(is.character(path) && length(path))
   path <- normalizePath(path, mustWork = FALSE)
   # Excel has no concept of a time zone, so decide once, for the whole workbook,

--- a/R/xl_sheet.R
+++ b/R/xl_sheet.R
@@ -151,6 +151,17 @@ xl_row_spec <- function(rows, height = NA, hidden = NA, level = NA,
 #'   open the file.
 #' @param first_tab Logical; make this the leftmost visible tab in the tab
 #'   strip.  This is independent of which sheet is active.
+#' @param hide_zero Logical; display zero values as blank cells.
+#' @param right_to_left Logical; order the columns right to left, for a sheet in
+#'   a right-to-left language.
+#' @param selection The cell or range selected when the sheet opens, as an Excel
+#'   reference (`"B2"`, `"B2:D10"`) or a `list(rows = , cols = )` spec.
+#'
+#'   Excel also uses the order of a selection's corners to mark which cell in it
+#'   is active; writexl does not expose that, because ranges are normalised by
+#'   the shared range parser, which rejects an inverted range.
+#' @param top_left The cell scrolled to the top-left of the window when the
+#'   sheet opens, as an Excel reference such as `"A5"`.
 #' @param page An [xl_page_setup()] describing how the sheet prints
 #'   (orientation, paper size, margins, scaling, header and footer). Affects
 #'   printing only, never the cell data.
@@ -173,7 +184,8 @@ xl_sheet <- function(data, cols = NULL, rows = NULL, freeze = NULL,
                      autofilter = FALSE, protect = FALSE,
                      comment_author = NA, show_comments = FALSE,
                      page = NULL, active = NA, selected = NA, visible = NA,
-                     first_tab = NA) {
+                     first_tab = NA, hide_zero = NA, right_to_left = NA,
+                     selection = NULL, top_left = NULL) {
   if (!is.data.frame(data))
     stop("`data` must be a data frame", call. = FALSE)
   if (!is.logical(auto_colwidth) || length(auto_colwidth) != 1L || is.na(auto_colwidth))
@@ -204,7 +216,11 @@ xl_sheet <- function(data, cols = NULL, rows = NULL, freeze = NULL,
       active         = .val_flag(active, "active"),
       selected       = .val_flag(selected, "selected"),
       visible        = .val_flag(visible, "visible"),
-      first_tab      = .val_flag(first_tab, "first_tab")
+      first_tab      = .val_flag(first_tab, "first_tab"),
+      hide_zero      = .val_flag(hide_zero, "hide_zero"),
+      right_to_left  = .val_flag(right_to_left, "right_to_left"),
+      selection      = selection,
+      top_left       = top_left
     ),
     class = "xl_sheet"
   )
@@ -433,8 +449,17 @@ print.xl_sheet <- function(x, ...) {
     overlay <- c(overlay, .as_overlay_list(el$overlay))
     protect <- .resolve_protect(el$protect)
     page_payload <- .page_setup_payload(el$page, df, header_offset)
-    for (k in c("active", "selected", "visible", "first_tab"))
+    for (k in c("active", "selected", "visible", "first_tab", "hide_zero",
+                "right_to_left"))
       if (!is.null(el[[k]])) view[[k]] <- as.integer(isTRUE(el[[k]]))
+    if (!is.null(el$selection))
+      view$selection <- .xl_resolve_range(el$selection, arg = "selection",
+                                          df = df, header_offset = header_offset,
+                                          allow_cell = TRUE)
+    if (!is.null(el$top_left))
+      view$top_left <- .xl_resolve_range(el$top_left, arg = "top_left",
+                                         df = df, header_offset = header_offset,
+                                         allow_cell = TRUE)[1:2]
     comment_author <- el$comment_author
     show_comments <- isTRUE(el$show_comments)
     # auto column widths (for columns the user did not size explicitly)

--- a/R/xl_sheet.R
+++ b/R/xl_sheet.R
@@ -141,6 +141,16 @@ xl_row_spec <- function(rows, height = NA, hidden = NA, level = NA,
 #'   per-comment `author` overrides it).
 #' @param show_comments If `TRUE`, all comments on the sheet are initially
 #'   shown (individual comments can still be forced via `xl_comment(visible=)`).
+#' @param active Logical; make this the tab Excel opens on.  At most one sheet
+#'   in a workbook may be active.
+#' @param selected Logical; include this tab in the selected group.  The active
+#'   sheet is always selected.
+#' @param visible Logical; `FALSE` hides the sheet's tab.  A hidden sheet cannot
+#'   be active or selected, the first sheet cannot be hidden unless another is
+#'   made active, and at least one sheet must stay visible or Excel will not
+#'   open the file.
+#' @param first_tab Logical; make this the leftmost visible tab in the tab
+#'   strip.  This is independent of which sheet is active.
 #' @param page An [xl_page_setup()] describing how the sheet prints
 #'   (orientation, paper size, margins, scaling, header and footer). Affects
 #'   printing only, never the cell data.
@@ -162,7 +172,8 @@ xl_sheet <- function(data, cols = NULL, rows = NULL, freeze = NULL,
                      default_row_height = NA, auto_colwidth = FALSE,
                      autofilter = FALSE, protect = FALSE,
                      comment_author = NA, show_comments = FALSE,
-                     page = NULL) {
+                     page = NULL, active = NA, selected = NA, visible = NA,
+                     first_tab = NA) {
   if (!is.data.frame(data))
     stop("`data` must be a data frame", call. = FALSE)
   if (!is.logical(auto_colwidth) || length(auto_colwidth) != 1L || is.na(auto_colwidth))
@@ -189,7 +200,11 @@ xl_sheet <- function(data, cols = NULL, rows = NULL, freeze = NULL,
       protect    = protect,
       comment_author = comment_author,
       show_comments  = show_comments,
-      page           = page
+      page           = page,
+      active         = .val_flag(active, "active"),
+      selected       = .val_flag(selected, "selected"),
+      visible        = .val_flag(visible, "visible"),
+      first_tab      = .val_flag(first_tab, "first_tab")
     ),
     class = "xl_sheet"
   )
@@ -374,6 +389,7 @@ print.xl_sheet <- function(x, ...) {
   comment_author <- NA_character_
   show_comments <- FALSE
   page_payload <- NULL
+  view <- list()
 
   if (inherits(el, "xl_sheet")) {
     # column specs
@@ -417,6 +433,8 @@ print.xl_sheet <- function(x, ...) {
     overlay <- c(overlay, .as_overlay_list(el$overlay))
     protect <- .resolve_protect(el$protect)
     page_payload <- .page_setup_payload(el$page, df, header_offset)
+    for (k in c("active", "selected", "visible", "first_tab"))
+      if (!is.null(el[[k]])) view[[k]] <- as.integer(isTRUE(el[[k]]))
     comment_author <- el$comment_author
     show_comments <- isTRUE(el$show_comments)
     # auto column widths (for columns the user did not size explicitly)
@@ -443,6 +461,7 @@ print.xl_sheet <- function(x, ...) {
     protect_password = protect$password, protect_options = protect$options,
     comment_author = as.character(comment_author),
     show_comments = as.integer(show_comments),
-    page = page_payload
+    page = page_payload,
+    view = if (length(view)) view else NULL
   )
 }

--- a/R/xl_sheet.R
+++ b/R/xl_sheet.R
@@ -162,6 +162,21 @@ xl_row_spec <- function(rows, height = NA, hidden = NA, level = NA,
 #'   the shared range parser, which rejects an inverted range.
 #' @param top_left The cell scrolled to the top-left of the window when the
 #'   sheet opens, as an Excel reference such as `"A5"`.
+#' @param split Split the sheet into scrollable panes with a visible, movable
+#'   divider, given as the cell reference the split sits above and to the left
+#'   of --- `"B3"` splits above row 3 and left of column B.  Mutually exclusive
+#'   with `freeze`, which does the same thing without the divider.
+#'
+#'   libxlsxwriter positions a split by distance, in row-height and
+#'   column-width units, not by row and column number.  writexl converts the
+#'   cell reference using the sheet's actual row heights and column widths, so
+#'   the split lands where you asked even after resizing.  Pass
+#'   `list(vertical = , horizontal = )` to give those units directly.
+#'
+#'   Note that libxlsxwriter derives the pane's scroll anchor back from that
+#'   distance assuming default row heights, so on a sheet with resized rows or
+#'   columns the divider is placed correctly but the anchor cell may be a row or
+#'   two out.
 #' @param page An [xl_page_setup()] describing how the sheet prints
 #'   (orientation, paper size, margins, scaling, header and footer). Affects
 #'   printing only, never the cell data.
@@ -185,7 +200,7 @@ xl_sheet <- function(data, cols = NULL, rows = NULL, freeze = NULL,
                      comment_author = NA, show_comments = FALSE,
                      page = NULL, active = NA, selected = NA, visible = NA,
                      first_tab = NA, hide_zero = NA, right_to_left = NA,
-                     selection = NULL, top_left = NULL) {
+                     selection = NULL, top_left = NULL, split = NULL) {
   if (!is.data.frame(data))
     stop("`data` must be a data frame", call. = FALSE)
   if (!is.logical(auto_colwidth) || length(auto_colwidth) != 1L || is.na(auto_colwidth))
@@ -220,7 +235,8 @@ xl_sheet <- function(data, cols = NULL, rows = NULL, freeze = NULL,
       hide_zero      = .val_flag(hide_zero, "hide_zero"),
       right_to_left  = .val_flag(right_to_left, "right_to_left"),
       selection      = selection,
-      top_left       = top_left
+      top_left       = top_left,
+      split          = split
     ),
     class = "xl_sheet"
   )
@@ -470,6 +486,18 @@ print.xl_sheet <- function(x, ...) {
         col_width[i] <- .auto_col_width(df[[i]], header)
       }
     }
+  }
+
+  # The split is resolved last, because converting a cell reference into
+  # libxlsxwriter's units needs the sheet's final row heights and column widths
+  # (including any set by auto_colwidth just above).
+  if (inherits(el, "xl_sheet") && !is.null(el$split)) {
+    if (!is.null(el$freeze) && !(length(el$freeze) == 1L && is.na(el$freeze)))
+      stop("`split` and `freeze` cannot both be set: Excel supports frozen ",
+           "panes or a split, not both", call. = FALSE)
+    view$split <- .resolve_split(el$split, df, header_offset, props,
+                                 default_row_height, row_row, row_height,
+                                 col_width)
   }
 
   col_format_id <- vapply(col_fmt, function(f) .register_format(reg, f), integer(1))

--- a/man/xl_sheet.Rd
+++ b/man/xl_sheet.Rd
@@ -26,7 +26,8 @@ xl_sheet(
   hide_zero = NA,
   right_to_left = NA,
   selection = NULL,
-  top_left = NULL
+  top_left = NULL,
+  split = NULL
 )
 }
 \arguments{
@@ -106,6 +107,22 @@ a right-to-left language.}
 
 \item{top_left}{The cell scrolled to the top-left of the window when the
 sheet opens, as an Excel reference such as `"A5"`.}
+
+\item{split}{Split the sheet into scrollable panes with a visible, movable
+  divider, given as the cell reference the split sits above and to the left
+  of --- `"B3"` splits above row 3 and left of column B.  Mutually exclusive
+  with `freeze`, which does the same thing without the divider.
+
+  libxlsxwriter positions a split by distance, in row-height and
+  column-width units, not by row and column number.  writexl converts the
+  cell reference using the sheet's actual row heights and column widths, so
+  the split lands where you asked even after resizing.  Pass
+  `list(vertical = , horizontal = )` to give those units directly.
+
+  Note that libxlsxwriter derives the pane's scroll anchor back from that
+  distance assuming default row heights, so on a sheet with resized rows or
+  columns the divider is placed correctly but the anchor cell may be a row or
+  two out.}
 }
 \value{
 An `xl_sheet` object.

--- a/man/xl_sheet.Rd
+++ b/man/xl_sheet.Rd
@@ -22,7 +22,11 @@ xl_sheet(
   active = NA,
   selected = NA,
   visible = NA,
-  first_tab = NA
+  first_tab = NA,
+  hide_zero = NA,
+  right_to_left = NA,
+  selection = NULL,
+  top_left = NULL
 )
 }
 \arguments{
@@ -87,6 +91,21 @@ open the file.}
 
 \item{first_tab}{Logical; make this the leftmost visible tab in the tab
 strip.  This is independent of which sheet is active.}
+
+\item{hide_zero}{Logical; display zero values as blank cells.}
+
+\item{right_to_left}{Logical; order the columns right to left, for a sheet in
+a right-to-left language.}
+
+\item{selection}{The cell or range selected when the sheet opens, as an Excel
+  reference (`"B2"`, `"B2:D10"`) or a `list(rows = , cols = )` spec.
+
+  Excel also uses the order of a selection's corners to mark which cell in it
+  is active; writexl does not expose that, because ranges are normalised by
+  the shared range parser, which rejects an inverted range.}
+
+\item{top_left}{The cell scrolled to the top-left of the window when the
+sheet opens, as an Excel reference such as `"A5"`.}
 }
 \value{
 An `xl_sheet` object.

--- a/man/xl_sheet.Rd
+++ b/man/xl_sheet.Rd
@@ -18,7 +18,11 @@ xl_sheet(
   protect = FALSE,
   comment_author = NA,
   show_comments = FALSE,
-  page = NULL
+  page = NULL,
+  active = NA,
+  selected = NA,
+  visible = NA,
+  first_tab = NA
 )
 }
 \arguments{
@@ -69,6 +73,20 @@ shown (individual comments can still be forced via `xl_comment(visible=)`).}
 \item{page}{An [xl_page_setup()] describing how the sheet prints
 (orientation, paper size, margins, scaling, header and footer). Affects
 printing only, never the cell data.}
+
+\item{active}{Logical; make this the tab Excel opens on.  At most one sheet
+in a workbook may be active.}
+
+\item{selected}{Logical; include this tab in the selected group.  The active
+sheet is always selected.}
+
+\item{visible}{Logical; `FALSE` hides the sheet's tab.  A hidden sheet cannot
+be active or selected, the first sheet cannot be hidden unless another is
+made active, and at least one sheet must stay visible or Excel will not
+open the file.}
+
+\item{first_tab}{Logical; make this the leftmost visible tab in the tab
+strip.  This is independent of which sheet is active.}
 }
 \value{
 An `xl_sheet` object.

--- a/src/write_xlsx.c
+++ b/src/write_xlsx.c
@@ -388,6 +388,22 @@ static void apply_page_setup(cell_write_ctx *ctx, SEXP opts){
   }
 }
 
+/*
+ * Apply the sheet's tab state.  The rules that make these mutually exclusive
+ * span the whole workbook and are checked in R by .resolve_sheet_visibility();
+ * libxlsxwriter enforces none of them, so by the time we get here the
+ * combination is known to be sane.
+ */
+static void apply_sheet_view(cell_write_ctx *ctx, SEXP opts){
+  SEXP v = list_get(opts, "view");
+  if(v == R_NilValue || !Rf_isVectorList(v)) return;
+  if(payload_int(v, "active"))    worksheet_activate(ctx->sheet);
+  if(payload_int(v, "selected"))  worksheet_select(ctx->sheet);
+  if(payload_has(v, "visible") && !payload_int(v, "visible"))
+    worksheet_hide(ctx->sheet);
+  if(payload_int(v, "first_tab")) worksheet_set_first_sheet(ctx->sheet);
+}
+
 /* Apply per-sheet scalar options (freeze panes, gridlines, tab color, ...). */
 static void apply_sheet_scalars(cell_write_ctx *ctx, SEXP opts){
   if(opts == R_NilValue) return;
@@ -1037,6 +1053,7 @@ SEXP C_write_data_frame_list(SEXP df_list, SEXP file, SEXP col_names,
     apply_columns(&ctx, opts, cols);
     apply_sheet_scalars(&ctx, opts);
     apply_page_setup(&ctx, opts);
+    apply_sheet_view(&ctx, opts);
     apply_sheet_overlays(&ctx, opts);
 
     // Need to iterate by row first for performance

--- a/src/write_xlsx.c
+++ b/src/write_xlsx.c
@@ -402,6 +402,26 @@ static void apply_sheet_view(cell_write_ctx *ctx, SEXP opts){
   if(payload_has(v, "visible") && !payload_int(v, "visible"))
     worksheet_hide(ctx->sheet);
   if(payload_int(v, "first_tab")) worksheet_set_first_sheet(ctx->sheet);
+  if(payload_int(v, "hide_zero"))     worksheet_hide_zero(ctx->sheet);
+  if(payload_int(v, "right_to_left")) worksheet_right_to_left(ctx->sheet);
+
+  /* Selected range and scroll position, both 0-based quads from R. */
+  SEXP sel = list_get(v, "selection");
+  if(sel != R_NilValue && Rf_length(sel) >= 4){
+    SEXP q = PROTECT(Rf_coerceVector(sel, INTSXP));
+    int *a = INTEGER(q);
+    assert_lxw(worksheet_set_selection(ctx->sheet, (lxw_row_t) a[0],
+                                       (lxw_col_t) a[1], (lxw_row_t) a[2],
+                                       (lxw_col_t) a[3]));
+    UNPROTECT(1);
+  }
+  SEXP tl = list_get(v, "top_left");
+  if(tl != R_NilValue && Rf_length(tl) >= 2){
+    SEXP q = PROTECT(Rf_coerceVector(tl, INTSXP));
+    int *a = INTEGER(q);
+    worksheet_set_top_left_cell(ctx->sheet, (lxw_row_t) a[0], (lxw_col_t) a[1]);
+    UNPROTECT(1);
+  }
 }
 
 /* Apply per-sheet scalar options (freeze panes, gridlines, tab color, ...). */

--- a/src/write_xlsx.c
+++ b/src/write_xlsx.c
@@ -415,6 +415,15 @@ static void apply_sheet_view(cell_write_ctx *ctx, SEXP opts){
                                        (lxw_col_t) a[3]));
     UNPROTECT(1);
   }
+  /* Split panes.  R has already converted the cell reference into
+     libxlsxwriter's row-height / column-width distances. */
+  SEXP sp = list_get(v, "split");
+  if(sp != R_NilValue && Rf_length(sp) >= 2){
+    SEXP q = PROTECT(Rf_coerceVector(sp, REALSXP));
+    worksheet_split_panes(ctx->sheet, REAL(q)[0], REAL(q)[1]);
+    UNPROTECT(1);
+  }
+
   SEXP tl = list_get(v, "top_left");
   if(tl != R_NilValue && Rf_length(tl) >= 2){
     SEXP q = PROTECT(Rf_coerceVector(tl, INTSXP));

--- a/tests/testthat/test-sheet-view.R
+++ b/tests/testthat/test-sheet-view.R
@@ -1,0 +1,116 @@
+# Sheet tab state.  These are the only worksheet settings whose rules span the
+# whole workbook, so most of these fixtures need more than one sheet.
+
+one <- function() data.frame(x = 1L)
+
+wb_xml <- function(sheets) {
+  xlsx_part(write_tmp(sheets), "xl/workbook.xml", raw = TRUE)
+}
+
+# ── What reaches the file ─────────────────────────────────────────────────────
+
+test_that("a hidden sheet is marked hidden in workbook.xml", {
+  x <- wb_xml(list(A = xl_sheet(one()), B = xl_sheet(one(), visible = FALSE)))
+  expect_match(x, '<sheet name="B" sheetId="2" state="hidden"', fixed = TRUE)
+  # the visible one is untouched
+  expect_match(x, '<sheet name="A" sheetId="1" r:id="rId1"/>', fixed = TRUE)
+})
+
+test_that("active and first_tab reach workbookView", {
+  x <- wb_xml(list(A = xl_sheet(one()),
+                   B = xl_sheet(one(), active = TRUE),
+                   C = xl_sheet(one(), first_tab = TRUE)))
+  expect_match(x, 'activeTab="1"', fixed = TRUE)   # 0-based: sheet B
+  expect_match(x, 'firstSheet="2"', fixed = TRUE)  # 0-based: sheet C
+})
+
+test_that("selected marks the tab without making it active", {
+  x <- xlsx_part(write_tmp(list(A = xl_sheet(one()),
+                                B = xl_sheet(one(), selected = TRUE))),
+                 "xl/worksheets/sheet2.xml", raw = TRUE)
+  expect_match(x, 'tabSelected="1"', fixed = TRUE)
+})
+
+test_that("visible = TRUE is not the same as unset, and neither hides", {
+  x <- wb_xml(list(A = xl_sheet(one(), visible = TRUE), B = xl_sheet(one())))
+  expect_false(grepl("state=", x, fixed = TRUE))
+})
+
+test_that("sheet view settings leave the cells alone", {
+  skip_if_not_installed("readxl")
+  df <- data.frame(a = 1:3, stringsAsFactors = FALSE)
+  p <- write_tmp(list(A = xl_sheet(df),
+                      B = xl_sheet(df, active = TRUE, first_tab = TRUE)))
+  expect_equal(as.data.frame(readxl::read_xlsx(p, sheet = "B")), df)
+})
+
+# ── The cross-sheet rules ─────────────────────────────────────────────────────
+
+test_that("hiding every sheet is refused", {
+  expect_error(write_tmp(list(A = xl_sheet(one(), visible = FALSE),
+                              B = xl_sheet(one(), visible = FALSE))),
+               "at least one visible sheet")
+})
+
+test_that("a hidden sheet cannot also be active or selected", {
+  expect_error(write_tmp(list(A = xl_sheet(one()),
+                              B = xl_sheet(one(), visible = FALSE,
+                                           active = TRUE))),
+               "hidden but also marked active/selected")
+  expect_error(write_tmp(list(A = xl_sheet(one()),
+                              B = xl_sheet(one(), visible = FALSE,
+                                           selected = TRUE))),
+               "hidden but also marked active/selected")
+})
+
+test_that("only one sheet may be active", {
+  expect_error(write_tmp(list(A = xl_sheet(one(), active = TRUE),
+                              B = xl_sheet(one(), active = TRUE))),
+               "only one sheet may be active")
+})
+
+test_that("the first sheet cannot be hidden unless another is activated", {
+  # Excel opens on the first sheet, so hiding it with nothing else active
+  # produces a workbook with no sheet to show
+  expect_error(write_tmp(list(A = xl_sheet(one(), visible = FALSE),
+                              B = xl_sheet(one()))),
+               "cannot be hidden unless another sheet")
+  # ... and it is allowed once another sheet is active
+  x <- wb_xml(list(A = xl_sheet(one(), visible = FALSE),
+                   B = xl_sheet(one(), active = TRUE)))
+  expect_match(x, '<sheet name="A" sheetId="1" state="hidden"', fixed = TRUE)
+  expect_match(x, 'activeTab="1"', fixed = TRUE)
+})
+
+test_that("error messages name the offending sheet", {
+  expect_error(write_tmp(list(Data = xl_sheet(one()),
+                              Notes = xl_sheet(one(), visible = FALSE,
+                                               active = TRUE))),
+               '"Notes"', fixed = TRUE)
+  expect_error(write_tmp(list(First = xl_sheet(one(), active = TRUE),
+                              Second = xl_sheet(one(), active = TRUE))),
+               '"First" and "Second"', fixed = TRUE)
+})
+
+test_that("unnamed sheets are identified by position in errors", {
+  expect_error(write_tmp(list(xl_sheet(one(), active = TRUE),
+                              xl_sheet(one(), active = TRUE))),
+               "sheets 1 and 2")
+})
+
+# ── Interaction with plain data frames ────────────────────────────────────────
+
+test_that("plain data frames are treated as unset and never trip the rules", {
+  # a bare data frame has no tab settings, so it must not be read as hidden
+  expect_silent(write_tmp(list(A = one(), B = one())))
+  # mixed with an xl_sheet
+  expect_silent(write_tmp(list(A = one(), B = xl_sheet(one(), active = TRUE))))
+  # a single plain data frame is not "every sheet hidden"
+  expect_silent(write_tmp(one()))
+})
+
+test_that("the flags are validated as logicals", {
+  expect_error(xl_sheet(one(), active = "yes"), "active")
+  expect_error(xl_sheet(one(), visible = 1), "visible")
+  expect_error(xl_sheet(one(), first_tab = c(TRUE, TRUE)), "first_tab")
+})

--- a/tests/testthat/test-sheet-view.R
+++ b/tests/testthat/test-sheet-view.R
@@ -181,3 +181,88 @@ test_that("the view scalars leave the cells alone", {
                                    selection = "A2", top_left = "A2")))
   expect_equal(as.data.frame(readxl::read_xlsx(p)), df)
 })
+
+# ── Split panes ───────────────────────────────────────────────────────────────
+#
+# worksheet_split_panes() positions the split by distance in row-height and
+# column-width units, not by row and column, so the interesting part is the
+# conversion.
+
+pane <- function(...) {
+  x <- xlsx_part(write_tmp(list(D = xl_sheet(data.frame(a = 1:5, b = 1:5,
+                                                        cc = 1:5), ...))),
+                 "xl/worksheets/sheet1.xml", raw = TRUE)
+  m <- regmatches(x, regexpr("<pane[^/]*/>", x))
+  if (!length(m)) NA_character_ else m
+}
+
+pane_num <- function(p, attr) {
+  m <- regmatches(p, regexec(sprintf('%s="([0-9.]+)"', attr), p))[[1L]]
+  if (length(m) == 2L) as.numeric(m[2L]) else 0
+}
+
+test_that("a split is placed from a cell reference", {
+  expect_match(pane(split = "B3"), "<pane ", fixed = TRUE)
+  # a split at B3 is below one header row plus one data row, and right of one
+  # column, so both distances are non-zero
+  expect_gt(pane_num(pane(split = "B3"), "ySplit"), 0)
+  expect_gt(pane_num(pane(split = "B3"), "xSplit"), 0)
+})
+
+test_that("a split on one axis only leaves the other unset", {
+  expect_equal(pane_num(pane(split = "A3"), "xSplit"), 0)
+  expect_gt(pane_num(pane(split = "A3"), "ySplit"), 0)
+  expect_equal(pane_num(pane(split = "B1"), "ySplit"), 0)
+  expect_gt(pane_num(pane(split = "B1"), "xSplit"), 0)
+})
+
+test_that("the split distance follows the sheet's real row heights", {
+  # this is the whole point of converting rather than assuming 15 per row:
+  # taller rows above the split must push it further down
+  base <- pane_num(pane(split = "A3"), "ySplit")
+  taller <- pane_num(pane(split = "A3", default_row_height = 30), "ySplit")
+  tallest <- pane_num(pane(split = "A3", rows = xl_row_spec(1, height = 45)),
+                      "ySplit")
+  expect_gt(taller, base)
+  expect_gt(tallest, taller)
+})
+
+test_that("the split distance follows the sheet's real column widths", {
+  base <- pane_num(pane(split = "B1"), "xSplit")
+  wider <- pane_num(pane(split = "B1", cols = xl_col_spec("a", width = 20)),
+                    "xSplit")
+  expect_gt(wider, base)
+})
+
+test_that("raw units can be given directly", {
+  p <- pane(split = list(vertical = 15, horizontal = 8.43))
+  expect_gt(pane_num(p, "ySplit"), 0)
+  expect_gt(pane_num(p, "xSplit"), 0)
+  # one axis only
+  expect_equal(pane_num(pane(split = list(vertical = 15)), "xSplit"), 0)
+})
+
+test_that("raw split units are validated", {
+  expect_error(write_tmp(list(D = xl_sheet(data.frame(x = 1),
+                                           split = list(vertical = -1)))),
+               "non-negative")
+  expect_error(write_tmp(list(D = xl_sheet(data.frame(x = 1),
+                                           split = list(sideways = 1)))),
+               "unknown `split`")
+})
+
+test_that("split and freeze cannot both be set", {
+  expect_error(write_tmp(list(D = xl_sheet(data.frame(x = 1:5),
+                                           split = "B2", freeze = "B2"))),
+               "cannot both be set")
+  # either alone is fine
+  expect_silent(write_tmp(list(D = xl_sheet(data.frame(x = 1:5), split = "B2"))))
+  expect_silent(write_tmp(list(D = xl_sheet(data.frame(x = 1:5), freeze = "B2"))))
+})
+
+test_that("a split leaves the cells alone", {
+  skip_if_not_installed("readxl")
+  df <- data.frame(a = 1:5, stringsAsFactors = FALSE)
+  p <- write_tmp(list(D = xl_sheet(df, split = "B3")))
+  expect_equal(as.data.frame(readxl::read_xlsx(p)), df)
+})

--- a/tests/testthat/test-sheet-view.R
+++ b/tests/testthat/test-sheet-view.R
@@ -114,3 +114,70 @@ test_that("the flags are validated as logicals", {
   expect_error(xl_sheet(one(), visible = 1), "visible")
   expect_error(xl_sheet(one(), first_tab = c(TRUE, TRUE)), "first_tab")
 })
+
+# ── Zero display, direction, selection and scroll position ───────────────────
+
+view_xml <- function(...) {
+  xlsx_part(write_tmp(list(D = xl_sheet(data.frame(x = 1:5), ...))),
+            "xl/worksheets/sheet1.xml", raw = TRUE)
+}
+
+test_that("hide_zero and right_to_left reach sheetView", {
+  expect_match(view_xml(hide_zero = TRUE), 'showZeros="0"', fixed = TRUE)
+  expect_match(view_xml(right_to_left = TRUE), 'rightToLeft="1"', fixed = TRUE)
+  # FALSE is not TRUE: nothing is written
+  expect_false(grepl("showZeros", view_xml(hide_zero = FALSE), fixed = TRUE))
+})
+
+test_that("selection accepts a single cell and a range", {
+  expect_match(view_xml(selection = "B2"), 'sqref="B2"', fixed = TRUE)
+  x <- view_xml(selection = "B2:C4")
+  expect_match(x, 'sqref="B2:C4"', fixed = TRUE)
+  # the top-left corner becomes the active cell
+  expect_match(x, 'activeCell="B2"', fixed = TRUE)
+})
+
+test_that("selection accepts a data-frame-relative spec", {
+  df <- data.frame(a = 1:5, b = 1:5)
+  x <- xlsx_part(write_tmp(list(D = xl_sheet(df, selection = list(rows = 1:2,
+                                                                 cols = "a")))),
+                 "xl/worksheets/sheet1.xml", raw = TRUE)
+  # data rows 1:2 are sheet rows 2:3 once the header is counted
+  expect_match(x, 'sqref="A2:A3"', fixed = TRUE)
+})
+
+test_that("an inverted selection is rejected by the shared range parser", {
+  # Excel would read the corner order as naming the active cell; writexl gives
+  # that up in exchange for one strict range parser, and says so rather than
+  # silently normalising
+  expect_error(write_tmp(list(D = xl_sheet(data.frame(x = 1:5),
+                                           selection = "C4:B2"))),
+               "inverted")
+})
+
+test_that("top_left sets the scrolled-to cell", {
+  expect_match(view_xml(top_left = "A3"), 'topLeftCell="A3"', fixed = TRUE)
+  expect_match(view_xml(top_left = "C10"), 'topLeftCell="C10"', fixed = TRUE)
+})
+
+test_that("selection and top_left are independent", {
+  x <- view_xml(selection = "B2", top_left = "A3")
+  expect_match(x, 'topLeftCell="A3"', fixed = TRUE)
+  expect_match(x, 'sqref="B2"', fixed = TRUE)
+})
+
+test_that("the view scalars are validated", {
+  expect_error(xl_sheet(data.frame(x = 1), hide_zero = "yes"), "hide_zero")
+  expect_error(xl_sheet(data.frame(x = 1), right_to_left = 1), "right_to_left")
+  expect_error(write_tmp(list(D = xl_sheet(data.frame(x = 1),
+                                           selection = "not a range"))),
+               "selection")
+})
+
+test_that("the view scalars leave the cells alone", {
+  skip_if_not_installed("readxl")
+  df <- data.frame(a = 1:5, stringsAsFactors = FALSE)
+  p <- write_tmp(list(D = xl_sheet(df, hide_zero = TRUE, right_to_left = TRUE,
+                                   selection = "A2", top_left = "A2")))
+  expect_equal(as.data.frame(readxl::read_xlsx(p)), df)
+})

--- a/vignettes/formatting.Rmd
+++ b/vignettes/formatting.Rmd
@@ -278,3 +278,60 @@ xl_page_setup(h_breaks = c(21, 41), v_breaks = "D")
 
 Excel ignores manual breaks when `fit_to` is set, and writexl warns if you ask
 for both.
+
+## Sheet tabs and the opening view
+
+`xl_sheet()` also controls the tab strip and what the user sees when the sheet
+opens.
+
+```{r}
+wb <- list(
+  Summary = xl_sheet(df, active = TRUE, selection = "B2"),
+  Detail  = xl_sheet(df, hide_zero = TRUE),
+  Working = xl_sheet(df, visible = FALSE)     # hidden tab
+)
+path <- write_xlsx(wb, tempfile(fileext = ".xlsx"))
+```
+
+`active` picks the tab Excel opens on, `selected` adds a tab to the selected
+group, `visible = FALSE` hides one, and `first_tab` chooses the leftmost tab in
+the strip.
+
+These are the only worksheet settings whose rules span the whole workbook, and
+writexl checks them before writing anything:
+
+* a hidden sheet cannot be active or selected;
+* at most one sheet may be active;
+* the first sheet cannot be hidden unless another is made active, because Excel
+  opens on the first sheet by default;
+* at least one sheet must stay visible, or Excel refuses to open the file.
+
+Each failure names the sheet at fault. libxlsxwriter enforces none of them, so
+without these checks a bad combination would produce a workbook that simply
+does not open.
+
+### Where the sheet is scrolled to
+
+`selection` sets the selected cell or range, and `top_left` the cell scrolled to
+the top-left of the window:
+
+```{r}
+xl_sheet(df, selection = "B2:D10", top_left = "A2")
+```
+
+### Freezing and splitting
+
+`freeze` locks rows and columns in place; `split` gives a movable divider with
+independent scroll bars instead. They are mutually exclusive.
+
+```{r}
+xl_sheet(df, freeze = "A2")   # keep the header row visible
+xl_sheet(df, split  = "B3")   # split above row 3 and left of column B
+```
+
+Note that libxlsxwriter positions a split by *distance*, in row-height and
+column-width units, rather than by row and column — `15` means one default-height
+row, `8.43` one default-width column. writexl converts the cell reference for
+you using the sheet's actual row heights and column widths, so a split still
+lands where you asked on a sheet whose rows or columns have been resized. Pass
+`list(vertical = , horizontal = )` if you would rather give the units directly.


### PR DESCRIPTION
Part of the libxlsxwriter API coverage roadmap. Fix #122

Covers 9 of 11 `worksheet.h` gaps in this area; 2 are deliberately skipped.

```r
wb <- list(
  Summary = xl_sheet(df, active = TRUE, selection = "B2"),
  Detail  = xl_sheet(df, hide_zero = TRUE, split = "B3"),
  Working = xl_sheet(df, visible = FALSE)
)
```

## Not implemented: `freeze_panes_opt()` and `split_panes_opt()`

Both are marked unsupported API upstream — `worksheet.h` line 4684:

```c
/* worksheet_freeze_panes() with infrequent options. Undocumented for now. */
```

They sit outside the Doxygen blocks covering every other function here. What
they add is `top_row` / `left_col`, which `worksheet_set_top_left_cell()`
already provides as documented API. Not worth depending on an interface
upstream has reserved the right to change.

## The interesting parts

**Cross-sheet validation — a first for this package.** Every previous phase
validated one sheet at a time. Excel's tab rules span the workbook, and
libxlsxwriter enforces *none* of them (`hide()`, `activate()` and `select()` all
return `void` and set a flag), so a bad combination produced a workbook that
would not open, silently. `.resolve_sheet_visibility()` now checks all four
before anything is written, naming the sheet at fault:

- a hidden sheet cannot be active or selected
- at most one sheet may be active
- the first sheet cannot be hidden unless another is made active — Excel opens
  on the first sheet by default
- at least one sheet must stay visible

**`split_panes()` takes distances, not rows and columns.** Its two arguments are
measured in row-height and column-width units, and the two units differ from
each other: `15` is one default row, `8.43` one default column. A user passing
`1` for "one row" would get a split a fifteenth of the way down the first row,
with no error.

`split` therefore takes a cell reference like `freeze` does, and converts using
the sheet's **actual** geometry — header row height, `xl_row_spec()` heights,
`xl_col_spec()` widths, `auto_colwidth` results — rather than assuming defaults.
Tests pin that sensitivity: a split at `A3` gives `ySplit` 900 with default
rows, 1200 under `default_row_height = 30`, and 1500 with an `xl_row_spec`
height of 45. `list(vertical = , horizontal = )` still accepts raw units, and
`split` with `freeze` is an error since Excel supports one or the other.

Documented caveat: libxlsxwriter derives the pane's scroll anchor back from that
distance assuming default row heights, so on a resized sheet the divider lands
correctly but the anchor cell can be a row or two out.

**One capability given up on purpose.** Excel encodes which cell of a selection
is active via the order of its corners — `worksheet_set_selection(6, 6, 3, 3)`
means "G7 to D4". The shared range resolver rejects inverted ranges, correctly
for every other caller, so writexl always makes the top-left corner active. One
strict range parser is worth more than a niche capability; a test pins the
error rather than letting it silently normalise.

## Verification

- **1002 tests pass, 0 failures**, 1 pre-existing skip
- `devtools::check()`: **0 errors, 0 warnings, 0 notes**
- Assertions against observed XML: `<sheet state="hidden">`, `activeTab`,
  `firstSheet` in `workbook.xml`; `tabSelected`, `showZeros`, `rightToLeft`,
  `topLeftCell`, `<selection>`, `<pane>` in the worksheet part
- Multi-sheet fixtures for every cross-sheet rule, including that plain data
  frames are treated as unset and never trip them
- The vignette renders

## Files

`R/sheet_visibility.R` (new), `R/split_panes.R` (new), `R/xl_sheet.R`,
`R/write_xlsx.R`, `src/write_xlsx.c`, `tests/testthat/test-sheet-view.R` (new),
`vignettes/formatting.Rmd`, `NEWS.md`.