### PR TITLE
Let a workbook, a column or a cell say what an empty cell should hold

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -84,6 +84,14 @@ carry the detail.
   out of the bundled `chart.h`, so a function added upstream surfaces as a
   failure rather than as a gap.
 
+* **A stand-in for missing values** via `na`, which writexl has always written
+  as an empty cell (#76). `write_xlsx(df, na = "not measured")` sets it for a
+  whole workbook, `xl_properties(na = )` does the same on a workbook object,
+  and `xl_col_spec(na = )` and `xl_cell_general(na = )` narrow it to one column
+  or one cell --- the innermost setting wins. It covers `NaN` as well as `NA`,
+  and keeps its own type, so `na = 0` writes a number and leaves a numeric
+  column numeric. The default, `na = NA`, is the empty cell as before.
+
 * Argument names are consistent across the new functions. Whatever a cell,
   label or box will show is `value`, whatever its type; a size in pixels says
   so (`width_pixels`); and a caption is `title`, with `title_format` and

--- a/R/write_xlsx.R
+++ b/R/write_xlsx.R
@@ -28,6 +28,12 @@
 #'   \code{\link{xl_properties}(header_format = )}.
 #' @param use_zip64 use \href{https://en.wikipedia.org/wiki/Zip_(file_format)#ZIP64}{zip64}
 #' to enable support for 4GB+ xlsx files. Not all platforms can read this.
+#' @param na what to write where a value has none. `NA` (the default) leaves
+#'   the cell blank, as writexl has always done; anything else is written in
+#'   its place, keeping its own type. Shorthand for
+#'   \code{\link{xl_properties}(na = )}, so give it there instead when `x` is
+#'   already an [xl_workbook]. A column or a single cell can override it: see
+#'   [xl_col_spec()] and [xl_cell_general()].
 #' @param constant_memory stream rows to disk instead of building the whole
 #'   workbook in memory. `NA` (the default) decides per workbook: on for large
 #'   data, off for small, and always off when a feature needs it off. `TRUE`
@@ -48,18 +54,23 @@
 #' tmp <- write_xlsx(list(mysheet = iris))
 #' readxl::read_xlsx(tmp)
 write_xlsx <- function(x, path = tempfile(fileext = ".xlsx"), col_names = TRUE,
-                       format_headers = TRUE, use_zip64 = FALSE,
+                       format_headers = TRUE, na = NA, use_zip64 = FALSE,
                        constant_memory = NA,
                        constant_memory_threshold = 128 * 1024^2){
   # Resolve the input to an xl_workbook.  A bare data frame / xl_sheet / list
   # is wrapped in a workbook with default properties; an explicit xl_workbook
   # overrides col_names/format_headers.
   if(inherits(x, "xl_workbook")){
+    # a workbook carries its own properties, so the shorthand has nowhere to go
+    # rather than somewhere surprising
+    if(!is.null(.val_na(na)))
+      stop("`na` is a shorthand for xl_properties(na = ); `x` is already an ",
+           "xl_workbook, so set it there", call. = FALSE)
     wb <- x
     col_names <- wb$col_names
     format_headers <- wb$format_headers
   } else {
-    wb <- xl_workbook(x, properties = xl_properties(),
+    wb <- xl_workbook(x, properties = xl_properties(na = na),
                       col_names = col_names, format_headers = format_headers)
   }
   props <- wb$properties

--- a/R/xl_cell_general.R
+++ b/R/xl_cell_general.R
@@ -13,7 +13,9 @@
 #' data frame column of a different length (just like [xl_formula()]).
 #'
 #' @param value An atomic vector or a list of scalars, one per cell. Use `NA`
-#'   to write an explicit empty cell. A list enables mixed types across cells
+#'   for a cell that is empty unless `na` says otherwise (see `na` below, and
+#'   note that a workbook-wide `na` reaches these values too). A list enables
+#'   mixed types across cells
 #'   in the same column (e.g., `list(1.5, "text", TRUE)`). Date and POSIXct
 #'   scalars are supported and formatted as in [write_xlsx()].  When
 #'   `hyperlink` is also set for the same cell, a **character** `value` is
@@ -55,6 +57,13 @@
 #'   an array formula.  On a cell that has no `formula` the flags are inert, so a
 #'   single `array = TRUE` can be recycled across a column that mixes formula
 #'   and value cells.
+#' @param na What to write in a cell that has no value, one per cell and
+#'   recycled.  `NA` (the default) inherits the column's
+#'   [xl_col_spec()]`(na = )`, and failing that the workbook's
+#'   [xl_properties()]`(na = )`; a cell that sets its own overrides both.  This
+#'   is also how a cell asks for a blank where the column or workbook would
+#'   otherwise substitute something --- give it the value you want, `""` for an
+#'   empty string.
 #' @param array_range The range a legacy array formula covers, for the rare case
 #'   where it must be declared: an Excel range string (`"C2:C11"`) or a
 #'   `list(rows = , cols = )` spec, one per cell (`NA` for none). It must start
@@ -102,13 +111,14 @@
 #' df$cell_col    <- xl_cell_general(value = 99L)  # all rows get 99
 xl_cell_general <- function(value = NULL, formula = NULL, hyperlink = NULL,
                             format = NULL, comment = NULL, array = FALSE,
-                            dynamic = FALSE, array_range = NULL) {
+                            dynamic = FALSE, array_range = NULL, na = NA) {
 
   # Require at least one content argument -------------------------------------
   if (is.null(value) && is.null(formula) && is.null(hyperlink) &&
       is.null(comment))
     stop("At least one of 'value', 'formula', 'hyperlink', or 'comment' must ",
-         "be provided. Use value = NA for an explicit empty cell.", call. = FALSE)
+         "be provided. Use value = NA for a cell with nothing in it.",
+         call. = FALSE)
 
   # Reject values writexl cannot write ----------------------------------------
   # Uses the same predicate as the column-level check in normalize_df(), so an
@@ -249,6 +259,15 @@ xl_cell_general <- function(value = NULL, formula = NULL, hyperlink = NULL,
                     formula_given = !is.null(formula))
   .check_rich_value(value_list, formula_vec, hyperlink_list)
 
+  # Normalise `na` to one entry per cell -------------------------------------
+  # NULL where the cell inherits, so C can tell "this cell says blank is fine"
+  # from "this cell has nothing to say".
+  na_src <- if (is.list(na)) na else as.list(na)
+  if (length(na_src) != 1L && length(na_src) != n)
+    stop(sprintf("`na` must be length 1 or %d (one per cell), not %d", n,
+                 length(na_src)), call. = FALSE)
+  na_list <- rep_len(lapply(na_src, .val_na, arg = "na"), n)
+
   # Build the per-cell records ------------------------------------------------
   cells <- lapply(seq_len(n), function(i) {
     list(
@@ -259,7 +278,8 @@ xl_cell_general <- function(value = NULL, formula = NULL, hyperlink = NULL,
       comment     = comment_list[[i]],
       array       = array_vec[[i]],
       dynamic     = dynamic_vec[[i]],
-      array_range = range_list[[i]]
+      array_range = range_list[[i]],
+      na          = na_list[[i]]
     )
   })
 

--- a/R/xl_format.R
+++ b/R/xl_format.R
@@ -74,6 +74,23 @@
   x
 }
 
+# What to write where a value has none.  Any single atomic value is kept with
+# its own type, so `na = 0` stays a number and `na = "-"` a string -- the cell
+# writer that handles ordinary values handles this one, which is why no type
+# table is needed here.  NA returns NULL, meaning "nothing set at this level":
+# a workbook then leaves the cell blank, and a column or a cell falls through
+# to the level above it.
+.val_na <- function(x, arg = "na") {
+  if (is.null(x)) return(NULL)
+  if (is.factor(x)) x <- as.character(x)
+  if (!is.atomic(x) || length(x) != 1L)
+    stop(sprintf(paste0("`%s` must be a single value of any type, or NA to ",
+                        "leave the cell blank"), arg), call. = FALSE)
+  # NaN is as unrepresentable as NA, so it cannot stand in for one either
+  if (is.na(x)) return(NULL)
+  x
+}
+
 .val_int <- function(x, arg, min = NA, max = NA) {
   if (.is_unset(x)) return(NULL)
   if (!is.numeric(x) || length(x) != 1L)

--- a/R/xl_sheet.R
+++ b/R/xl_sheet.R
@@ -42,6 +42,10 @@
 #'   as 100 pixels is 13.57 character units.
 #' @param hidden Logical; hide the column/row.
 #' @param level Integer outline (grouping) level, 0--7.
+#' @param na What to write in this column where a value has none, overriding
+#'   the workbook's [xl_properties()]`(na = )`. `NA` (the default) inherits it.
+#'   Columns are where this usually belongs: a substitute that suits a numeric
+#'   column rarely suits a date one.
 #' @param collapsed Logical; draw this column/row as the collapsed summary of
 #'   the group beside it.  Excel does not derive this --- the rows or columns
 #'   of the group itself need `hidden = TRUE` as well, exactly as clicking the
@@ -87,7 +91,8 @@ NULL
 #' @rdname xl_colrow_spec
 #' @export
 xl_col_spec <- function(cols, width = NA, hidden = NA, level = NA,
-                        format = NULL, width_pixels = NA, collapsed = NA) {
+                        format = NULL, width_pixels = NA, collapsed = NA,
+                        na = NA) {
   if (missing(cols) || length(cols) < 1L)
     stop("`cols` must name or index at least one column", call. = FALSE)
   if (!is.character(cols) && !is.numeric(cols))
@@ -98,7 +103,8 @@ xl_col_spec <- function(cols, width = NA, hidden = NA, level = NA,
                            .pixels_to_width),
     hidden = .val_flag(hidden, "hidden"),
     level  = .val_int(level, "level", min = 0, max = 7),
-    collapsed = .val_flag(collapsed, "collapsed")
+    collapsed = .val_flag(collapsed, "collapsed"),
+    na = .val_na(na)
   ))
   .new_colrow_spec("col", list(kind = "col", index = cols), geometry, format)
 }
@@ -465,6 +471,8 @@ print.xl_sheet <- function(x, ...) {
   col_hidden <- rep(NA_integer_, ncols)
   col_level  <- rep(NA_integer_, ncols)
   col_collapsed <- rep(NA_integer_, ncols)
+  # a list, not a vector: each column's `na` keeps its own type
+  col_na <- vector("list", ncols)
   explicit_width <- rep(FALSE, ncols)   # columns whose width the user set
   for (i in seq_len(ncols)) {
     base <- props$default_format
@@ -504,6 +512,7 @@ print.xl_sheet <- function(x, ...) {
         if (!is.null(geo$level))  col_level[i]  <- as.integer(geo$level)
         if (!is.null(geo$collapsed))
           col_collapsed[i] <- as.integer(isTRUE(geo$collapsed))
+        if (!is.null(geo$na)) col_na[[i]] <- geo$na
       }
     }
     # row specs
@@ -624,6 +633,7 @@ print.xl_sheet <- function(x, ...) {
     col_width = col_width, col_format_id = col_format_id,
     col_hidden = col_hidden, col_level = col_level,
     col_collapsed = col_collapsed,
+    col_na = if (any(lengths(col_na))) col_na else NULL,
     row_row = row_row, row_height = row_height, row_format_id = row_fmt_id,
     row_hidden = row_hidden, row_level = row_level,
     row_collapsed = row_collapsed,

--- a/R/xl_workbook.R
+++ b/R/xl_workbook.R
@@ -28,6 +28,14 @@
 #'   Left `NA` libxlsxwriter stamps the moment the file is written, which is
 #'   what makes two runs over the same data differ; pinning it makes them
 #'   byte-identical.
+#' @param na What to write where a value has none --- an `NA` or `NaN` in the
+#'   data, or a cell with nothing in it at all. `NA` (the default) leaves the
+#'   cell blank, which is what writexl has always done. Anything else is
+#'   written in its place, keeping its own type: `na = "Not available"` writes
+#'   a string, `na = 0` a number. A column or an individual cell can override
+#'   it --- see [xl_col_spec()] and [xl_cell_general()]. Note that a non-blank
+#'   `na` in a numeric column makes that column mixed, so a reader such as
+#'   [readxl::read_xlsx()] returns the whole column as character.
 #' @param custom A named list of custom document properties.  Values may be
 #'   character, integer, numeric, logical, `Date` or `POSIXct`.  A `Date` or
 #'   `POSIXct` is written as a real datetime property (not as text) and follows
@@ -69,7 +77,8 @@
 xl_properties <- function(title = NA, subject = NA, author = NA, manager = NA,
                           company = NA, category = NA, keywords = NA,
                           comments = NA, status = NA, hyperlink_base = NA,
-                          created = NA, custom = NULL, read_only = FALSE, window_size = NULL,
+                          created = NA, na = NA, custom = NULL,
+                          read_only = FALSE, window_size = NULL,
                           names = NULL,
                           default_format   = xl_format(),
                           header_format    = xl_font(bold = TRUE) +
@@ -106,7 +115,8 @@ xl_properties <- function(title = NA, subject = NA, author = NA, manager = NA,
     list(title = title, subject = subject, author = author, manager = manager,
          company = company, category = category, keywords = keywords,
          comments = comments, status = status, hyperlink_base = hyperlink_base,
-         created = created, custom = custom, read_only = read_only, window_size = window_size,
+         created = created, na = .val_na(na), custom = custom,
+         read_only = read_only, window_size = window_size,
          names = names,
          default_format = default_format, header_format = header_format,
          hyperlink_format = hyperlink_format, date_format = date_format,
@@ -316,6 +326,7 @@ print.xl_workbook <- function(x, ...) {
     v <- props[[k]]
     if (!is.null(v) && !(length(v) == 1L && is.na(v))) out[[k]] <- as.character(v)
   }
+  if (!is.null(props$na)) out$na <- props$na
   cr <- props$created
   if (!is.null(cr) && !(length(cr) == 1L && is.na(cr))) {
     if (!inherits(cr, "Date") && !inherits(cr, "POSIXct"))

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -51,6 +51,7 @@ lightyellow
 ltr
 mislabelled
 mouseover
+na
 nativeRaster
 normalised
 num

--- a/man/write_xlsx.Rd
+++ b/man/write_xlsx.Rd
@@ -10,6 +10,7 @@ write_xlsx(
   path = tempfile(fileext = ".xlsx"),
   col_names = TRUE,
   format_headers = TRUE,
+  na = NA,
   use_zip64 = FALSE,
   constant_memory = NA,
   constant_memory_threshold = 128 * 1024^2
@@ -26,6 +27,13 @@ data frames / `xl_sheet`s that become the sheets in the xlsx}
 \item{format_headers}{apply the workbook's header format to that header row?
 The default header format is bold and centered; change it with
 \code{\link{xl_properties}(header_format = )}.}
+
+\item{na}{what to write where a value has none. `NA` (the default) leaves
+the cell blank, as writexl has always done; anything else is written in
+its place, keeping its own type. Shorthand for
+\code{\link{xl_properties}(na = )}, so give it there instead when `x` is
+already an [xl_workbook]. A column or a single cell can override it: see
+[xl_col_spec()] and [xl_cell_general()].}
 
 \item{use_zip64}{use \href{https://en.wikipedia.org/wiki/Zip_(file_format)#ZIP64}{zip64}
 to enable support for 4GB+ xlsx files. Not all platforms can read this.}

--- a/man/xl_cell_general.Rd
+++ b/man/xl_cell_general.Rd
@@ -13,14 +13,17 @@ xl_cell_general(
   comment = NULL,
   array = FALSE,
   dynamic = FALSE,
-  array_range = NULL
+  array_range = NULL,
+  na = NA
 )
 
 \method{as.character}{xl_cell_general}(x, ...)
 }
 \arguments{
 \item{value}{An atomic vector or a list of scalars, one per cell. Use `NA`
-to write an explicit empty cell. A list enables mixed types across cells
+for a cell that is empty unless `na` says otherwise (see `na` below, and
+note that a workbook-wide `na` reaches these values too). A list enables
+mixed types across cells
 in the same column (e.g., `list(1.5, "text", TRUE)`). Date and POSIXct
 scalars are supported and formatted as in [write_xlsx()].  When
 `hyperlink` is also set for the same cell, a **character** `value` is
@@ -79,6 +82,14 @@ and value cells.}
   is the right spelling for a `SUMPRODUCT`-style aggregate. Supplying it
   forces the workbook out of the memory-efficient row-streaming mode, since
   libxlsxwriter cannot pad an array range while streaming.}
+
+\item{na}{What to write in a cell that has no value, one per cell and
+recycled.  `NA` (the default) inherits the column's
+[xl_col_spec()]`(na = )`, and failing that the workbook's
+[xl_properties()]`(na = )`; a cell that sets its own overrides both.  This
+is also how a cell asks for a blank where the column or workbook would
+otherwise substitute something --- give it the value you want, `""` for an
+empty string.}
 
 \item{x}{An `xl_cell_general`.}
 

--- a/man/xl_colrow_spec.Rd
+++ b/man/xl_colrow_spec.Rd
@@ -13,7 +13,8 @@ xl_col_spec(
   level = NA,
   format = NULL,
   width_pixels = NA,
-  collapsed = NA
+  collapsed = NA,
+  na = NA
 )
 
 xl_row_spec(
@@ -49,6 +50,11 @@ as 100 pixels is 13.57 character units.}
 the group beside it.  Excel does not derive this --- the rows or columns
 of the group itself need `hidden = TRUE` as well, exactly as clicking the
 grouping symbol would leave them.}
+
+\item{na}{What to write in this column where a value has none, overriding
+the workbook's [xl_properties()]`(na = )`. `NA` (the default) inherits it.
+Columns are where this usually belongs: a substitute that suits a numeric
+column rarely suits a date one.}
 
 \item{rows}{Rows to target: a numeric vector of 1-based data-row indices
 (row 1 is the first data row, ignoring the header).}

--- a/man/xl_properties.Rd
+++ b/man/xl_properties.Rd
@@ -16,6 +16,7 @@ xl_properties(
   status = NA,
   hyperlink_base = NA,
   created = NA,
+  na = NA,
   custom = NULL,
   read_only = FALSE,
   window_size = NULL,
@@ -37,6 +38,15 @@ xl_properties(
 Left `NA` libxlsxwriter stamps the moment the file is written, which is
 what makes two runs over the same data differ; pinning it makes them
 byte-identical.}
+
+\item{na}{What to write where a value has none --- an `NA` or `NaN` in the
+data, or a cell with nothing in it at all. `NA` (the default) leaves the
+cell blank, which is what writexl has always done. Anything else is
+written in its place, keeping its own type: `na = "Not available"` writes
+a string, `na = 0` a number. A column or an individual cell can override
+it --- see [xl_col_spec()] and [xl_cell_general()]. Note that a non-blank
+`na` in a numeric column makes that column mixed, so a reader such as
+[readxl::read_xlsx()] returns the whole column as character.}
 
 \item{custom}{A named list of custom document properties.  Values may be
 character, integer, numeric, logical, `Date` or `POSIXct`.  A `Date` or

--- a/src/write_xlsx.c
+++ b/src/write_xlsx.c
@@ -179,7 +179,23 @@ typedef struct {
   int            sheet_protected;  /* is this worksheet protected?            */
   int           *warn_unlocked;    /* set when protection formatting is used  */
                                    /* on an unprotected sheet                 */
+  SEXP           wb_na;   /* workbook-wide stand-in for a missing value      */
+  SEXP           col_na;  /* VECSXP, one per column; element NULL = inherit  */
 } cell_write_ctx;
+
+/* What to write where a value has none: the cell's own `na`, else the
+   column's, else the workbook's.  Each level is absent when it was NA on the
+   R side, so an unset level falls through and an unset workbook yields
+   R_NilValue -- which write_na() declines, leaving the blank writexl has
+   always written. */
+static SEXP resolve_na(cell_write_ctx *ctx, lxw_col_t col, SEXP cell_na){
+  if(cell_na != R_NilValue && Rf_length(cell_na)) return cell_na;
+  if(ctx->col_na != R_NilValue && Rf_xlength(ctx->col_na) > (R_xlen_t) col){
+    SEXP v = VECTOR_ELT(ctx->col_na, col);
+    if(v != R_NilValue && Rf_length(v)) return v;
+  }
+  return ctx->wb_na;
+}
 
 /* Resolve a 1-based format id to a format pointer (0 or out-of-range -> NULL) */
 static lxw_format *ctx_format(cell_write_ctx *ctx, int id){
@@ -1787,6 +1803,17 @@ static int write_atomic_value(cell_write_ctx *ctx, lxw_row_t row, lxw_col_t col,
   }
 }
 
+/* Write the stand-in for a value that had none, and report whether it wrote a
+   cell.  An unset `na` is R_NilValue and writes nothing, which is what keeps
+   the default identical to the blank writexl has always written.  It goes
+   through the same dispatcher as an ordinary value, so `na` works for every
+   type a column can hold without a second type table. */
+static int write_na(cell_write_ctx *ctx, lxw_row_t row, lxw_col_t col,
+                     SEXP na, lxw_format *fmt){
+  if(na == R_NilValue || Rf_length(na) == 0) return 0;
+  return write_atomic_value(ctx, row, col, na, get_type(na), 0, fmt);
+}
+
 /* --- xl_cell_general field accessors ------------------------------------- */
 
 /* A per-cell logical field, absent or NA reading as FALSE. */
@@ -2019,8 +2046,11 @@ static void write_cell_general(cell_write_ctx *ctx,
      cell.  Plain (non-xl_cell_general) columns are deliberately left alone:
      their NAs are covered by the column format Excel already applies. */
   if(value == R_NilValue || Rf_isNull(value) || Rf_length(value) == 0 ||
-     !write_atomic_value(ctx, row, col_idx, value, get_type(value), 0, fmt))
-    assert_lxw(worksheet_write_blank(ctx->sheet, row, col_idx, fmt));
+     !write_atomic_value(ctx, row, col_idx, value, get_type(value), 0, fmt)){
+    if(!write_na(ctx, row, col_idx,
+                 resolve_na(ctx, col_idx, list_get(cell, "na")), fmt))
+      assert_lxw(worksheet_write_blank(ctx->sheet, row, col_idx, fmt));
+  }
 }
 
 /* --- Top-level cell dispatcher ------------------------------------------- */
@@ -2029,8 +2059,8 @@ static void write_cell(cell_write_ctx *ctx, lxw_row_t row, lxw_col_t col,
                         SEXP col_data, R_COL_TYPE type, lxw_row_t i){
   if(type == COL_CELL_GENERAL)
     write_cell_general(ctx, row, col, col_data, i);
-  else
-    write_atomic_value(ctx, row, col, col_data, type, i, NULL);
+  else if(!write_atomic_value(ctx, row, col, col_data, type, i, NULL))
+    write_na(ctx, row, col, resolve_na(ctx, col, R_NilValue), NULL);
 }
 
 /* --- Workbook document properties ---------------------------------------- */
@@ -2239,7 +2269,8 @@ SEXP C_write_data_frame_list(SEXP df_list, SEXP file, SEXP col_names,
     int sheet_protected = opt_scalar_int(opts, "protect", 0);
     int warn_unlocked = 0;
     cell_write_ctx ctx = {workbook, sheet, fmts, nfmts, fmt_prot,
-                          sheet_protected, &warn_unlocked};
+                          sheet_protected, &warn_unlocked,
+                          list_get(properties, "na"), list_get(opts, "col_na")};
 
     // Apply column geometry/formats and sheet-level options (freeze, etc.),
     // then the range-scoped overlays.  All of this must precede the row loop

--- a/tests/testthat/test-na.R
+++ b/tests/testthat/test-na.R
@@ -1,0 +1,208 @@
+# What gets written where a value has none.
+#
+# writexl has always left such a cell blank.  `na` substitutes something else,
+# at three scopes -- a cell, a column, the workbook -- with the innermost one
+# that is set winning.  The default, `na = NA`, must keep the blank, and the
+# first test proves that byte for byte rather than by inspection: this is the
+# whole compatibility story for a package whose reverse dependencies all write
+# data frames with NAs in them.
+
+na_df <- function() data.frame(
+  num  = c(1.5, NA, NaN),
+  int  = c(1L, NA, 3L),
+  chr  = c("a", NA, "c"),
+  lgl  = c(TRUE, NA, FALSE),
+  date = as.Date(c("2024-01-01", NA, "2024-03-01")),
+  time = as.POSIXct(c("2024-01-01 10:00:00", NA, "2024-03-01 12:00:00"),
+                    tz = "UTC"),
+  stringsAsFactors = FALSE
+)
+
+sheet_xml_of <- function(...) {
+  p <- tempfile(fileext = ".xlsx")
+  write_xlsx(..., path = p)
+  xlsx_part(p, "xl/worksheets/sheet1.xml", raw = TRUE)
+}
+
+# A string cell holds an index into sharedStrings.xml, so counting occurrences
+# of a substitute means counting them there -- once per distinct string, which
+# is why these tests count cells that point at it rather than the string.
+shared_has <- function(p, s)
+  grepl(s, xlsx_part(p, "xl/sharedStrings.xml", raw = TRUE), fixed = TRUE)
+
+# ── The default changes nothing ───────────────────────────────────────────────
+
+test_that("na = NA writes exactly what writing no `na` at all writes", {
+  df <- na_df()
+  # every scope explicitly unset, which is what the defaults already are
+  explicit <- sheet_xml_of(list(D = xl_sheet(
+    df, cols = xl_col_spec("num", na = NA))), na = NA)
+  implicit <- sheet_xml_of(list(D = df))
+  expect_equal(explicit, implicit)
+  # and a blank cell is still no cell: the row holds only the non-NA columns
+  expect_false(grepl("<c r=\"A3\"", implicit, fixed = TRUE))
+})
+
+test_that("the whole file is unchanged by the default, not just one sheet", {
+  # xl_properties() gained an argument; the properties payload must not have
+  # grown a key that reaches the file when nothing asked for one.  `created` is
+  # pinned so the only thing that could differ is the change under test rather
+  # than the timestamp libxlsxwriter stamps on each run.
+  df <- na_df()
+  when <- as.POSIXct("2024-01-01 00:00:00", tz = "UTC")
+  bytes <- function(...) {
+    p <- write_tmp(xl_workbook(list(D = df),
+                               properties = xl_properties(created = when, ...)))
+    readBin(p, "raw", file.size(p))
+  }
+  expect_equal(bytes(na = NA), bytes())
+})
+
+# ── Every column type ─────────────────────────────────────────────────────────
+
+test_that("a workbook-wide na fills in for every column type, NaN included", {
+  p <- write_tmp(na_df(), na = "none")
+  got <- as.data.frame(readxl::read_xlsx(p))
+  # the substitute makes each column mixed, so readxl reports character
+  for (col in names(got))
+    expect_equal(got[[col]][2L], "none", info = col)
+  # NaN is as unwritable as NA, so it is filled in too
+  expect_equal(got$num[3L], "none")
+  # and the values that do exist are untouched
+  expect_equal(got$chr[1L], "a")
+  expect_equal(got$int[3L], "3")
+})
+
+test_that("na keeps its own type rather than becoming a string", {
+  p <- write_tmp(data.frame(x = c(1.5, NA)), na = 0)
+  got <- as.data.frame(readxl::read_xlsx(p))
+  # still a numeric column, because the substitute is a number
+  expect_type(got$x, "double")
+  expect_equal(got$x, c(1.5, 0))
+
+  # a logical substitute stays a boolean cell
+  x <- sheet_xml_of(list(D = data.frame(a = c("k", NA), stringsAsFactors = FALSE)),
+                    na = TRUE)
+  expect_match(x, 't="b"', fixed = TRUE)
+})
+
+test_that("Inf is unaffected: it has a representation already", {
+  p <- write_tmp(data.frame(x = c(Inf, -Inf, NA)), na = "none")
+  got <- as.data.frame(readxl::read_xlsx(p))
+  expect_equal(got$x, c("Inf", "-Inf", "none"))
+})
+
+# ── Scopes ────────────────────────────────────────────────────────────────────
+
+test_that("a column's na overrides the workbook's", {
+  df <- data.frame(a = c(1, NA), b = c(1, NA), c = c(1, NA))
+  p <- write_tmp(xl_workbook(
+    list(D = xl_sheet(df, cols = list(xl_col_spec("a", na = -999),
+                                      xl_col_spec("b", na = "gone")))),
+    properties = xl_properties(na = "WB")))
+  got <- as.data.frame(readxl::read_xlsx(p))
+  # a number keeps the column numeric; a string makes it mixed
+  expect_equal(got$a[2L], -999)     # column wins
+  expect_equal(got$b[2L], "gone")   # column wins
+  expect_equal(got$c[2L], "WB")     # no column setting, so the workbook's
+})
+
+test_that("a cell's na overrides the column's and the workbook's", {
+  df <- data.frame(a = 1:3)
+  df$mix <- xl_cell_general(value = list(1, NA, NA), na = c(NA, "CELL", NA))
+  p <- write_tmp(xl_workbook(
+    list(D = xl_sheet(df, cols = xl_col_spec("mix", na = "COL"))),
+    properties = xl_properties(na = "WB")))
+  got <- as.data.frame(readxl::read_xlsx(p))
+  expect_equal(got$mix, c("1", "CELL", "COL"))
+})
+
+test_that("a cell reaches the workbook's na with no column between", {
+  df <- data.frame(a = 1:2)
+  df$mix <- xl_cell_general(value = list(1, NA))
+  p <- write_tmp(xl_workbook(list(D = xl_sheet(df)),
+                             properties = xl_properties(na = "WB")))
+  expect_equal(as.data.frame(readxl::read_xlsx(p))$mix, c("1", "WB"))
+})
+
+# ── What na must not touch ────────────────────────────────────────────────────
+
+test_that("a cell that has content keeps it", {
+  df <- data.frame(a = 1:3)
+  # a formula and a hyperlink are content, not missing values
+  df$f <- xl_cell_general(formula = c("=A2+1", NA, NA))
+  df$h <- xl_cell_general(hyperlink = c("https://example.com", NA, NA))
+  p <- write_tmp(xl_workbook(list(D = xl_sheet(df)),
+                             properties = xl_properties(na = "none")))
+  x <- xlsx_part(p, "xl/worksheets/sheet1.xml", raw = TRUE)
+  # the formula cell still holds its formula
+  expect_match(x, "A2+1", fixed = TRUE)
+  expect_true(shared_has(p, "none"))
+  # the four cells that have neither formula nor value take the substitute,
+  # and the two that have content do not
+  got <- as.data.frame(readxl::read_xlsx(p))
+  expect_equal(got$f[2:3], c("none", "none"))
+  expect_equal(got$h[2:3], c("none", "none"))
+  expect_false(identical(got$f[1L], "none"))
+})
+
+test_that("the header row is never substituted", {
+  # a header is always written, so it has no missing value to stand in for --
+  # this pins that `na` never reaches it
+  df <- data.frame(none = c(1, NA))
+  p <- write_tmp(list(D = df), na = "none")
+  got <- as.data.frame(readxl::read_xlsx(p))
+  expect_equal(names(got), "none")
+  expect_equal(got$none, c("1", "none"))
+})
+
+test_that("a formatted blank keeps its format when substituted", {
+  df <- data.frame(a = 1:2)
+  df$b <- xl_cell_general(value = list(1, NA), format = xl_font(bold = TRUE),
+                          na = "none")
+  p <- write_tmp(list(D = xl_sheet(df)))
+  x <- xlsx_part(p, "xl/worksheets/sheet1.xml", raw = TRUE)
+  expect_true(shared_has(p, "none"))
+  # the substituted cell carries the same style as the value cell above it,
+  # which is the format the blank it replaces would have kept
+  styles <- regmatches(x, gregexpr('<c r="B[23]" s="[0-9]+"', x))[[1L]]
+  expect_length(styles, 2L)
+  expect_equal(sub('.*s="', "", styles[1L]), sub('.*s="', "", styles[2L]))
+  expect_match(xlsx_part(p, "xl/styles.xml", raw = TRUE), "<b/>", fixed = TRUE)
+})
+
+# ── Validation ────────────────────────────────────────────────────────────────
+
+test_that("na must be a single value of some atomic type", {
+  expect_error(xl_properties(na = c("a", "b")), "must be a single value")
+  expect_error(xl_properties(na = list(1)), "must be a single value")
+  expect_error(xl_col_spec("a", na = mean), "must be a single value")
+  expect_error(xl_cell_general(value = 1, na = list(1, 2)),
+               "must be length 1 or 1")
+  expect_error(xl_cell_general(value = 1:3, na = c("a", "b")),
+               "must be length 1 or 3")
+  # a factor is taken as its label
+  expect_equal(unclass(xl_properties(na = factor("gone")))$na, "gone")
+  # NaN cannot stand in for a missing value either, so it reads as unset
+  expect_null(unclass(xl_properties(na = NaN))$na)
+  expect_null(unclass(xl_properties(na = NA))$na)
+})
+
+test_that("a per-cell na may leave some cells to inherit", {
+  # NULL and NA both mean "nothing set here", so a list can mix cells that
+  # override with cells that fall through to the column or the workbook
+  df <- data.frame(a = 1:3)
+  df$mix <- xl_cell_general(value = list(NA, NA, NA),
+                            na = list("CELL", NULL, NA))
+  p <- write_tmp(xl_workbook(list(D = xl_sheet(df)),
+                             properties = xl_properties(na = "WB")))
+  expect_equal(as.data.frame(readxl::read_xlsx(p))$mix,
+               c("CELL", "WB", "WB"))
+})
+
+test_that("write_xlsx's na shorthand refuses to be silently ignored", {
+  wb <- xl_workbook(list(D = data.frame(a = c(1, NA))))
+  expect_error(write_tmp(wb, na = "none"), "already an xl_workbook")
+  # without the shorthand the workbook's own setting applies
+  expect_silent(write_tmp(wb))
+})

--- a/vignettes/a-getting-started.Rmd
+++ b/vignettes/a-getting-started.Rmd
@@ -56,6 +56,18 @@ Column types map to Excel's own:
 --- `complex`, `raw`, a plain list column --- is an error rather than a silent
 approximation.
 
+`na` writes something else in place of an empty cell, for `NaN` as well as
+`NA`. It keeps its own type, so a number stays a number:
+
+```{r}
+tmp <- write_xlsx(data.frame(x = c(1.5, NA)), na = "not measured")
+```
+
+Set it for the whole workbook with `xl_properties(na = )`, for one column with
+`xl_col_spec(na = )`, or for one cell with `xl_cell_general(na = )`; the
+innermost one that is set wins. Substituting a string into a numeric column
+makes that column mixed, so reading it back gives character.
+
 Excel has no concept of a time zone, so `POSIXct` needs a decision. writexl
 makes it once for the whole workbook: if every value shares one zone the local
 wall-clock reading is written, and if they differ everything is converted to


### PR DESCRIPTION
Closes #76.

writexl writes an empty cell wherever a value has none, which is not always
what a reader wants to see. `na` names a stand-in:

```r
write_xlsx(df, path, na = "not measured")
```

## Three scopes, innermost wins

| Set it on | For |
| --- | --- |
| `xl_properties(na = )` — `write_xlsx(na = )` is the shorthand | a whole workbook |
| `xl_col_spec(na = )` | one column |
| `xl_cell_general(na = )` | one cell |

`NA` at any level means "nothing set here", so a cell falls through to its
column and a column to its workbook. A per-cell `na` may be a list, and a `NULL`
element leaves that one cell to inherit.

Columns are usually the right place: a substitute that suits a numeric column
rarely suits a date one.

## The substitute keeps its own type

`na = 0` writes a number and leaves a numeric column numeric. `na = "none"`
makes that column mixed, which a reader such as readxl then returns as
character — the documented cost of asking for a non-numeric value in a numeric
column.

That falls out of routing the value through `write_atomic_value()`, the same
dispatcher an ordinary cell value goes through. Every type writexl can write,
`na` can write, and there is no second type table to keep in step.

`NaN` is covered alongside `NA`, having no representation either. `Inf` is not,
since it already writes as `"Inf"`.

## The default is not a behaviour change, and the test proves it

An unset `na` reaches C as `R_NilValue`, `write_na()` declines it, and the same
`worksheet_write_blank()` call runs as before.

Rather than assert that, a test compares **whole workbooks byte for byte** with
`created` pinned, so the only thing that could differ is the change under test
rather than the timestamp libxlsxwriter stamps on each run. This is the whole
compatibility story for a package whose reverse dependencies all write data
frames with NAs in them, so it is worth pinning at that strength.

## A cell with content is untouched

The substitution sits at the point where `write_atomic_value()` reports it had
nothing to write — which is already *after* the formula, hyperlink and
rich-string branches. So a formula cell keeps its formula, and only a cell with
no content at all takes the stand-in. A formatted blank keeps its format, as it
did before.

The header row is never substituted: it is always written, so it has no missing
value to stand in for. A test pins that too.

## Three decisions made while implementing

1. **`write_xlsx(na = )` errors when `x` is already an `xl_workbook`**, pointing
   at `xl_properties(na = )`. The workbook carries its own properties, so the
   shorthand would otherwise be silently ignored — the same trap `col_names`
   already has, but this one is new so it can fail loudly instead.
2. **A length-2 `na` on a one-cell column was silently truncating.** Caught by a
   test written for something else; it now errors naming the length it wanted.
3. **`xl_cell_general()`'s documented promise changed.** *"Use `value = NA` for
   an explicit empty cell"* stops being true once a workbook `na` is set, so the
   wording is updated and `na` is documented as how a cell asks for its blank
   back.

## Known limitation

There is no spelling for *"this column writes a blank even though the workbook
substitutes something"*. `NA` means inherit at the inner scopes, so it cannot
also mean override-to-blank. `na = ""` gets an empty string, which is close but
not the same cell. Easy to add later if anyone wants it.

## Verification

- `R CMD check`: 0 errors, 0 warnings, 0 notes
- `lintr::lint_package()`: 0
- **100% of every R line** covered; `src/write_xlsx.c` at 99.26%, the same
  defensive lines as before
- Spelling clean
- `src/libxlsxwriter/` untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)