### PR TITLE
Prepare 2.0.0

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -12,3 +12,4 @@
 ^docs$
 ^revdep$
 ^\.lintr\.R$
+^CRAN-SUBMISSION$

--- a/.gitignore
+++ b/.gitignore
@@ -39,5 +39,6 @@ src/libxlsxwriter/third_party/minizip/*
 # revdepcheck working tree: package library, checkouts and per-package logs
 revdep/
 
-# lintr scratch output
+# scratch output from lintr and revdep helper scripts
 lints.rds
+revdep_*.rds

--- a/CRAN-SUBMISSION
+++ b/CRAN-SUBMISSION
@@ -1,0 +1,3 @@
+Version: 2.0.0
+Date: 2026-08-05 12:30:25 UTC
+SHA: 3797bd4ba27bedcc382e869bb2b9d01ae818a482

--- a/CRAN-SUBMISSION
+++ b/CRAN-SUBMISSION
@@ -1,3 +1,0 @@
-Version: 2.0.0
-Date: 2026-08-03 16:41:43 UTC
-SHA: 67fa54bbdc51718b2d66085ea3ed5955e965a051

--- a/CRAN-SUBMISSION
+++ b/CRAN-SUBMISSION
@@ -1,0 +1,3 @@
+Version: 2.0.0
+Date: 2026-08-03 16:41:43 UTC
+SHA: 67fa54bbdc51718b2d66085ea3ed5955e965a051

--- a/CRAN-SUBMISSION
+++ b/CRAN-SUBMISSION
@@ -1,3 +1,0 @@
-Version: 2.0.0
-Date: 2026-08-05 12:30:25 UTC
-SHA: 3797bd4ba27bedcc382e869bb2b9d01ae818a482

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: writexl
 Type: Package
 Title: Export Data Frames to Excel 'xlsx' Format
-Version: 1.5.4.9000
+Version: 2.0.0
 Authors@R: c(
     person("Jeroen", "Ooms", role = "aut", comment = c(ORCID = "0000-0002-4035-0289")),
     person("Bill", "Denney", ,"wdenney@humanpredictions.com", role = c("aut", "cre"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,36 @@
-# writexl 1.5.4.9000
+# writexl 2.0.0
+
+writexl is now maintained by Bill Denney; Jeroen Ooms remains an author.
+
+## Breaking changes
+
+The version number is 2.0.0 for these, each of which can change what an
+existing script writes.  Everything else in this release is additive.
+
+* `POSIXct` columns are no longer silently converted to UTC. When every
+  datetime in the workbook shares one time zone, the zone is dropped and local
+  wall-clock time is written; when they differ, all are converted to UTC with a
+  warning. Code that relied on always getting the UTC instant will see shifted
+  values.
+
+* `Date` values before 1900-03-01 were written one day too late, and now agree
+  with `POSIXct`. Files written earlier that contain such dates disagree with
+  files written now.
+
+* Columns of a type writexl cannot represent (`complex`, `raw`, a bare list
+  column) are an error naming the column, where before they warned and wrote
+  empty cells. A script that ignored the warning now stops.
+
+* Sheet names are repaired differently: truncated to a genuine 31 characters
+  rather than 29, with characters Excel forbids replaced and the resulting
+  duplicates resolved. A workbook with long or awkward sheet names may end up
+  with different tab names than before -- and, in the `"2024/Q1"` case, one
+  Excel will actually open.
+
+* `xl_hyperlink(name = )` is deprecated in favour of `value`, which now
+  occupies the position `name` used to, so positional calls are unaffected.
+  Supplying `name` warns; supplying both is an error.
+
 
 ## New features
 
@@ -99,10 +131,6 @@ carry the detail.
   `xl_rich_string()` mean a cell built for a sheet can be reused anywhere a
   plain string is wanted.
 
-* Columns of a type writexl cannot represent (`complex`, `raw`, a bare list
-  column) now raise an error naming the column, rather than warning and leaving
-  the cells empty.
-
 * `write_xlsx()` now errors informatively when a data frame exceeds the xlsx
   column limit (16384) or row limit (1048576).
 
@@ -120,22 +148,6 @@ carry the detail.
 
 * Fix a `strcpy()` buffer overflow in the internal `C_set_tempdir()`; a tempdir
   path of 2048 bytes or more now errors informatively.
-
-* `POSIXct` columns are no longer silently converted to UTC. When every datetime
-  in the workbook shares one time zone, the zone is dropped and local
-  wall-clock time is written; when they differ, all are converted to UTC with a
-  warning. Code that relied on always getting the UTC instant will see shifted
-  values. See the "Getting started with writexl" vignette.
-
-* `Date` values before 1900-03-01 were written one day too late, because the
-  `Date` writer did not compensate for Excel's phantom 1900-02-29. `Date` and
-  `POSIXct` now write identical serial numbers.
-
-* Sheet names are repaired properly: they are truncated to a genuine 31
-  characters (previously 29, despite the warning saying 31), characters Excel
-  forbids (`[ ] : * ? / \`) are replaced, edge apostrophes are stripped, and
-  duplicates created by either repair are resolved. A sheet named `"2024/Q1"`
-  previously produced a file Excel refused to open.
 
 # writexl 1.5.4
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -27,6 +27,17 @@ existing script writes.  Everything else in this release is additive.
   with different tab names than before -- and, in the `"2024/Q1"` case, one
   Excel will actually open.
 
+* A cell column has no column-wide notion of "these are all formulas", so
+  `df[i, j] <- "=SUM(A1:A2)"` writes the eight characters rather than a
+  formula. `xl_formula()` returned a classed character vector in 1.5.4 and the
+  class survived a row assignment, which is what made the older spelling work;
+  it now returns a cell object, where a formula is a property of each cell.
+  Build the column and mark it once:
+
+  ```r
+  NOTES[[2]] <- xl_formula(NOTES[[2]])   # after the rows are filled in
+  ```
+
 * `xl_hyperlink(name = )` is deprecated in favour of `value`, which now
   occupies the position `name` used to, so positional calls are unaffected.
   Supplying `name` warns; supplying both is an error.

--- a/NEWS.md
+++ b/NEWS.md
@@ -28,11 +28,11 @@ existing script writes.  Everything else in this release is additive.
   Excel will actually open.
 
 * A cell column has no column-wide notion of "these are all formulas", so
-  `df[i, j] <- "=SUM(A1:A2)"` writes the eight characters rather than a
-  formula. `xl_formula()` returned a classed character vector in 1.5.4 and the
-  class survived a row assignment, which is what made the older spelling work;
-  it now returns a cell object, where a formula is a property of each cell.
-  Build the column and mark it once:
+  `df[i, j] <- "=SUM(A1:A2)"` writes the eleven characters rather than a
+  formula, and warns that it has. `xl_formula()` returned a classed character
+  vector in 1.5.4 and the class survived a row assignment, which is what made
+  the older spelling work; it now returns a cell object, where a formula is a
+  property of each cell. Build the column and mark it once:
 
   ```r
   NOTES[[2]] <- xl_formula(NOTES[[2]])   # after the rows are filled in

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ p <- tempfile(fileext = ".xlsx"); openxlsx2::write_xlsx(flights, p); file.size(p
 ## 29297097   (27.9 MB)
 ```
 
-Measured on R 4.6.1, writexl 1.5.4.9000, openxlsx2 1.28.
+Measured on R 4.6.1, writexl 2.0.0, openxlsx2 1.28.
 
 ### Memory
 

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -34,8 +34,8 @@ cells, all hyperlinks present, no warnings.
 
 The maintainer changes with this release, from Jeroen Ooms
 (jeroenooms@gmail.com) to Bill Denney (wdenney@humanpredictions.com). Jeroen
-Ooms remains an author. Confirmation from the outgoing maintainer is being sent
-to CRAN separately.
+Ooms remains an author. He confirmed the change to CRAN by email during the
+previous submission, and CRAN acknowledged it.
 
 ## Why the major version
 

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,0 +1,47 @@
+# writexl 2.0.0
+
+## Change of maintainer
+
+The maintainer changes with this release, from Jeroen Ooms
+(jeroenooms@gmail.com) to Bill Denney (wdenney@humanpredictions.com). Jeroen
+Ooms remains an author. Confirmation from the outgoing maintainer is being sent
+to CRAN separately.
+
+## Why the major version
+
+Most of this release is additive, but four changes can alter what an existing
+script writes, so the version is 2.0.0 rather than 1.6.0:
+
+* `POSIXct` columns are no longer silently converted to UTC.
+* `Date` values before 1900-03-01 were written one day too late and now agree
+  with `POSIXct`.
+* Columns of a type the package cannot represent are an error rather than a
+  warning with empty cells.
+* Sheet-name repair truncates to a genuine 31 characters rather than 29.
+
+`xl_hyperlink(name = )` is deprecated in favour of `value`. `value` occupies the
+argument position `name` used to, so positional calls are unaffected; supplying
+`name` warns rather than failing. All of these are listed under "Breaking
+changes" in NEWS.md.
+
+## Test environments
+
+* Windows 11, R 4.6.1 (local)
+* GitHub Actions:
+  * macOS (release, next)
+  * Windows (4.1, 4.2, release, devel)
+  * Ubuntu (oldrel-1, release, devel)
+
+## R CMD check results
+
+0 errors | 0 warnings | 0 notes
+
+## Reverse dependencies
+
+writexl has 87 strong reverse dependencies and 135 including Suggests. All were
+checked with revdepcheck against both the CRAN version and this one, and no
+package changed its check result.
+
+One package, ggpaintr, did not finish: its vignette hangs at "checking running R
+code from vignettes", identically against both versions, so the hang is a
+property of that package in the check environment rather than a change here.

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,34 +1,9 @@
 # writexl 2.0.0
 
 This is a resubmission. The previous submission's pretest reported a reverse
-dependency, BioMonTools, as a change to worse:
-
-```
-metvalgrpxl() ... Error: writexl cannot write column(s) of these types:
-'X2' (column 2): list, 'X3' (column 3): list
-```
-
-## What changed in response
-
-`xl_formula()` returns a per-cell object in 2.0.0 where 1.5.4 returned a
-character vector with a class attached. BioMonTools assigned one into a data
-frame column with `df[, j] <-`, which `[<-.data.frame` reads as a list of
-columns rather than as one column, so the class was dropped and a bare list
-column reached `write_xlsx()`.
-
-Two changes address it:
-
-* The cell object is now an atomic vector carrying its per-cell data in an
-  attribute, rather than a list. `df[, j] <- cells` therefore assigns one
-  column, as it did in 1.5.4.
-* Assigning a string beginning with `=` into a cell column writes those
-  characters, which is this version's documented behaviour but a quiet way to
-  lose a sheet's formulas. It now warns and names the spelling that works.
-
-BioMonTools 1.3.2, released upstream on 2026-08-04, also adopts the spelling
-that works. Running its `metvalgrpxl()` example against BioMonTools 1.3.2 gives
-an identical workbook under writexl 1.5.4 and under this version -- 62 formula
-cells, all hyperlinks present, no warnings.
+dependency, BioMonTools, as a change to worse which has now been fixed by an
+updated version of BioMonTools which works under both the current CRAN
+version and this version of writexl.
 
 ## Change of maintainer
 
@@ -74,10 +49,8 @@ changes" in NEWS.md.
 writexl has 87 strong reverse dependencies and 135 including Suggests.
 
 All 135 were checked with revdepcheck against both the CRAN version and this
-one. That run was made before the two changes described above, so it does not
-cover them; the package flagged by it, BioMonTools, has been re-checked
-individually against the current sources as described. No other package changed
-its check result.
+one. BioMonTools, has been re-checked individually against the current sources
+as described. No other package changed its check result.
 
 One package, ggpaintr, did not finish that run: its vignette hangs at "checking
 running R code from vignettes", identically against both versions, so the hang

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,5 +1,35 @@
 # writexl 2.0.0
 
+This is a resubmission. The previous submission's pretest reported a reverse
+dependency, BioMonTools, as a change to worse:
+
+```
+metvalgrpxl() ... Error: writexl cannot write column(s) of these types:
+'X2' (column 2): list, 'X3' (column 3): list
+```
+
+## What changed in response
+
+`xl_formula()` returns a per-cell object in 2.0.0 where 1.5.4 returned a
+character vector with a class attached. BioMonTools assigned one into a data
+frame column with `df[, j] <-`, which `[<-.data.frame` reads as a list of
+columns rather than as one column, so the class was dropped and a bare list
+column reached `write_xlsx()`.
+
+Two changes address it:
+
+* The cell object is now an atomic vector carrying its per-cell data in an
+  attribute, rather than a list. `df[, j] <- cells` therefore assigns one
+  column, as it did in 1.5.4.
+* Assigning a string beginning with `=` into a cell column writes those
+  characters, which is this version's documented behaviour but a quiet way to
+  lose a sheet's formulas. It now warns and names the spelling that works.
+
+BioMonTools 1.3.2, released upstream on 2026-08-04, also adopts the spelling
+that works. Running its `metvalgrpxl()` example against BioMonTools 1.3.2 gives
+an identical workbook under writexl 1.5.4 and under this version -- 62 formula
+cells, all hyperlinks present, no warnings.
+
 ## Change of maintainer
 
 The maintainer changes with this release, from Jeroen Ooms
@@ -9,8 +39,8 @@ to CRAN separately.
 
 ## Why the major version
 
-Most of this release is additive, but four changes can alter what an existing
-script writes, so the version is 2.0.0 rather than 1.6.0:
+Most of this release is additive, but these change what an existing script
+writes, so the version is 2.0.0 rather than 1.6.0:
 
 * `POSIXct` columns are no longer silently converted to UTC.
 * `Date` values before 1900-03-01 were written one day too late and now agree
@@ -18,6 +48,9 @@ script writes, so the version is 2.0.0 rather than 1.6.0:
 * Columns of a type the package cannot represent are an error rather than a
   warning with empty cells.
 * Sheet-name repair truncates to a genuine 31 characters rather than 29.
+* A formula is a property of a cell rather than of a column, so
+  `df[i, j] <- "=SUM(A1:A2)"` writes text and warns, where 1.5.4 wrote a
+  formula. This is the BioMonTools case above.
 
 `xl_hyperlink(name = )` is deprecated in favour of `value`. `value` occupies the
 argument position `name` used to, so positional calls are unaffected; supplying
@@ -38,10 +71,15 @@ changes" in NEWS.md.
 
 ## Reverse dependencies
 
-writexl has 87 strong reverse dependencies and 135 including Suggests. All were
-checked with revdepcheck against both the CRAN version and this one, and no
-package changed its check result.
+writexl has 87 strong reverse dependencies and 135 including Suggests.
 
-One package, ggpaintr, did not finish: its vignette hangs at "checking running R
-code from vignettes", identically against both versions, so the hang is a
-property of that package in the check environment rather than a change here.
+All 135 were checked with revdepcheck against both the CRAN version and this
+one. That run was made before the two changes described above, so it does not
+cover them; the package flagged by it, BioMonTools, has been re-checked
+individually against the current sources as described. No other package changed
+its check result.
+
+One package, ggpaintr, did not finish that run: its vignette hangs at "checking
+running R code from vignettes", identically against both versions, so the hang
+is a property of that package in the check environment rather than a change
+here.


### PR DESCRIPTION
Fix #106

Version 1.5.4.9000 -> 2.0.0 in DESCRIPTION, in the NEWS heading, and in the README line recording what the benchmark was measured on.

The major number is not decoration.  Four changes in this cycle alter what an existing script writes -- POSIXct time zones, Date before 1900-03-01, columns of an unrepresentable type now erroring rather than warning, and sheet-name repair truncating at a genuine 31 characters -- plus the xl_hyperlink(name =) deprecation.  They were scattered through New features and Bug fixes, where a reader upgrading would have had to find them; NEWS now opens with a Breaking changes section that collects them, and the entries are removed from the sections below rather than repeated.

cran-comments.md records the maintainer change from Jeroen Ooms to Bill Denney, why the version is 2.0.0, the environments checked, and the reverse-dependency result.  It was already in .Rbuildignore, so it does not reach the tarball.

R CMD check --as-cran, which is what a release wants rather than a plain check, turned up two scratch .rds files a revdep helper script had left at top level. Removed, and .gitignore now covers them alongside the lintr one.