### PR TITLE
Make a cell vector a vector, so it can be assigned as one column

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -2,6 +2,10 @@
 
 S3method("+",xl_format)
 S3method("[",xl_cell_general)
+S3method("[<-",xl_cell_general)
+S3method("[[",xl_cell_general)
+S3method("[[<-",xl_cell_general)
+S3method("length<-",xl_cell_general)
 S3method(as.character,xl_cell_general)
 S3method(as.character,xl_rich_string)
 S3method(as.data.frame,xl_cell_general)

--- a/NEWS.md
+++ b/NEWS.md
@@ -92,17 +92,6 @@ carry the detail.
   and keeps its own type, so `na = 0` writes a number and leaves a numeric
   column numeric. The default, `na = NA`, is the empty cell as before.
 
-* `xl_cell_general()` is a vector rather than a list, so a cell column can be
-  assigned with `df[, j] <- cells` and not only with `df[[j]] <- cells`.
-  `[<-.data.frame` reads a list value as a list of *columns*, which scattered
-  one cell record per column and dropped the class; the records now ride in an
-  attribute behind an integer index, the shape `factor` uses. `[`, `[[`, `c()`,
-  `rep()` and `length()` are unchanged from a caller's point of view.
-
-  `df[i, j] <- x` sets that cell's value. A formula needs `xl_formula()`: a
-  cell column has no column-wide "these are all formulas", which is what
-  writexl 1.5.4 carried on the column's class.
-
 * Argument names are consistent across the new functions. Whatever a cell,
   label or box will show is `value`, whatever its type; a size in pixels says
   so (`width_pixels`); and a caption is `title`, with `title_format` and

--- a/NEWS.md
+++ b/NEWS.md
@@ -92,6 +92,17 @@ carry the detail.
   and keeps its own type, so `na = 0` writes a number and leaves a numeric
   column numeric. The default, `na = NA`, is the empty cell as before.
 
+* `xl_cell_general()` is a vector rather than a list, so a cell column can be
+  assigned with `df[, j] <- cells` and not only with `df[[j]] <- cells`.
+  `[<-.data.frame` reads a list value as a list of *columns*, which scattered
+  one cell record per column and dropped the class; the records now ride in an
+  attribute behind an integer index, the shape `factor` uses. `[`, `[[`, `c()`,
+  `rep()` and `length()` are unchanged from a caller's point of view.
+
+  `df[i, j] <- x` sets that cell's value. A formula needs `xl_formula()`: a
+  cell column has no column-wide "these are all formulas", which is what
+  writexl 1.5.4 carried on the column's class.
+
 * Argument names are consistent across the new functions. Whatever a cell,
   label or box will show is `value`, whatever its type; a size in pixels says
   so (`width_pixels`); and a caption is `title`, with `title_format` and

--- a/R/excel_types.R
+++ b/R/excel_types.R
@@ -33,7 +33,8 @@
 
 .cell_holds_rich_string <- function(x) {
   inherits(x, "xl_cell_general") &&
-    any(vapply(x, function(el) is_xl_rich_string(el[["value"]]), logical(1)))
+    any(vapply(.cell_records(x), function(el) is_xl_rich_string(el[["value"]]),
+               logical(1)))
 }
 
 #' Excel Types

--- a/R/write_xlsx.R
+++ b/R/write_xlsx.R
@@ -172,7 +172,7 @@ write_xlsx <- function(x, path = tempfile(fileext = ".xlsx"), col_names = TRUE,
       if(inherits(col, "POSIXct")){
         out <- c(out, .tzone_of(col))
       } else if(inherits(col, "xl_cell_general")){
-        for(rec in unclass(col))
+        for(rec in .cell_records(col))
           if(inherits(rec$value, "POSIXct"))
             out <- c(out, .tzone_of(rec$value))
       }
@@ -203,7 +203,7 @@ write_xlsx <- function(x, path = tempfile(fileext = ".xlsx"), col_names = TRUE,
     if(inherits(col, "POSIXct")){
       df[[j]] <- .drop_tzone(col)
     } else if(inherits(col, "xl_cell_general")){
-      recs <- unclass(col)
+      recs <- .cell_records(col)
       touched <- FALSE
       for(k in seq_along(recs)){
         if(inherits(recs[[k]]$value, "POSIXct")){
@@ -212,7 +212,7 @@ write_xlsx <- function(x, path = tempfile(fileext = ".xlsx"), col_names = TRUE,
         }
       }
       if(touched)
-        df[[j]] <- structure(recs, class = class(col))
+        df[[j]] <- .new_cell_vector(recs)
     }
   }
   df
@@ -255,7 +255,7 @@ write_xlsx <- function(x, path = tempfile(fileext = ".xlsx"), col_names = TRUE,
   for (j in seq_along(df)) {
     col <- df[[j]]
     if (!inherits(col, "xl_cell_general")) next
-    recs <- unclass(col)
+    recs <- .cell_records(col)
     ids <- vapply(recs, .resolve_cell_format_id, integer(1), reg = reg, props = props)
     for (k in seq_along(recs)) {
       rec <- recs[[k]]
@@ -284,7 +284,7 @@ write_xlsx <- function(x, path = tempfile(fileext = ".xlsx"), col_names = TRUE,
       rec$array_range <- NULL
       recs[[k]] <- rec
     }
-    col <- structure(recs, class = class(col))
+    col <- .new_cell_vector(recs)
     attr(col, "writexl_format_ids") <- ids
     df[[j]] <- col
   }

--- a/R/xl_cell_general.R
+++ b/R/xl_cell_general.R
@@ -9,8 +9,14 @@
 #' result, or a URL with separate display text and tooltip).
 #'
 #' An `xl_cell_general` behaves like a vector: it has a `length()`, supports
-#' `[`, `c()`, and `rep()`, and recycles automatically when assigned to a
-#' data frame column of a different length (just like [xl_formula()]).
+#' `[`, `[[`, `c()` and `rep()`, and recycles automatically when assigned to a
+#' data frame column of a different length (just like [xl_formula()]).  It is
+#' deliberately not a list, so that `df[, j] <- cells` assigns one column
+#' rather than being read as a list of them.
+#'
+#' `df[i, j] <- x` sets that cell's `value`, whatever `x`'s type; a formula
+#' needs [xl_formula()], since a cell column carries no column-wide notion of
+#' "these are all formulas".
 #'
 #' @param value An atomic vector or a list of scalars, one per cell. Use `NA`
 #'   for a cell that is empty unless `na` says otherwise (see `na` below, and
@@ -283,7 +289,43 @@ xl_cell_general <- function(value = NULL, formula = NULL, hyperlink = NULL,
     )
   })
 
-  structure(cells, class = c("xl_cell_general", "xl_cell"))
+  .new_cell_vector(cells)
+}
+
+# --- The object ---------------------------------------------------------------
+#
+# An xl_cell_general is an integer vector carrying its per-cell records in an
+# attribute, the shape factor uses.  The integers are bookkeeping: they are
+# always seq_along(records), and nothing reads them.  What matters is that the
+# object is *not* a list, because `[<-.data.frame` treats a list value as a
+# list of columns -- so `df[, j] <- cells` assigned one cell record per column
+# and lost the class, which is what broke a reverse dependency on 2.0.0.
+#
+# The carrier is an integer rather than the displayed text on purpose.  If the
+# class is ever stripped -- recycling into a longer frame does it, in base R
+# and in writexl 1.5.4 alike -- an integer leaves an obviously wrong 1, 2, 3
+# rather than plausible-looking text that would write as silently wrong cells.
+
+# The carrier is the authority on length, not the records.  R extends a data
+# frame's rows through xpdrows.data.frame(), which does `class(y) <- NULL;
+# length(y) <- n; attributes(y) <- saved` -- it strips the class, pads the
+# carrier, and puts the old attributes back verbatim, so no method of ours is
+# consulted and the records come back short.  Padding them here on the way out
+# makes the object heal itself: the new cells read as empty, which is what
+# extending a data frame means.
+.cell_records <- function(x) {
+  r <- attr(x, "records", exact = TRUE)
+  n <- length(unclass(x))
+  if (length(r) != n) {
+    length(r) <- n
+    r <- .fill_empty_cells(r)
+  }
+  r
+}
+
+.new_cell_vector <- function(records) {
+  structure(seq_along(records), records = records,
+            class = c("xl_cell_general", "xl_cell"))
 }
 
 #' @description
@@ -296,7 +338,7 @@ xl_cell_general <- function(value = NULL, formula = NULL, hyperlink = NULL,
 #' @rdname xl_cell_general
 #' @export
 as.character.xl_cell_general <- function(x, ...) {
-  vapply(x, function(el) {
+  vapply(.cell_records(x), function(el) {
     v <- el[["value"]]
     if (is_xl_rich_string(v)) as.character(v)
     else if (is.null(v) || length(v) != 1L) NA_character_
@@ -399,17 +441,69 @@ length.xl_cell_general <- function(x) length(unclass(x))
 
 #' @export
 `[.xl_cell_general` <- function(x, i, ...) {
-  structure(unclass(x)[i], class = class(x))
+  .new_cell_vector(.cell_records(x)[i])
+}
+
+# `x[[i]]` is one cell's record, the named list of its fields -- the carrier is
+# bookkeeping and never the answer to a question about a cell.
+#' @export
+`[[.xl_cell_general` <- function(x, i, ...) .cell_records(x)[[i]]
+
+#' @export
+`[[<-.xl_cell_general` <- function(x, i, value) {
+  recs <- .cell_records(x)
+  recs[[i]] <- value
+  .new_cell_vector(recs)
+}
+
+# Assigning into a cell column has to reach the records.  Without this method
+# `df[i, j] <- value` writes into the integer carrier instead -- silently, and
+# leaving the records one short -- because that is where `[<-.data.frame`
+# sends it.  A bare value becomes the cell's `value`; an xl_cell_general on
+# the right replaces those cells outright.
+#' @export
+`[<-.xl_cell_general` <- function(x, i, value) {
+  recs <- .cell_records(x)
+  repl <- if (inherits(value, "xl_cell_general")) .cell_records(value)
+          else .cell_records(xl_cell_general(value = value))
+  # `i` may point past the end -- `d[3, 2] <-` on a one-row frame does exactly
+  # that -- so index the list directly and let it grow.  seq_along(recs)[i]
+  # would give NA there and drop the assignment on the floor.
+  k <- if (is.logical(i)) sum(i, na.rm = TRUE) else length(i)
+  recs[i] <- rep_len(repl, k)
+  .new_cell_vector(.fill_empty_cells(recs))
+}
+
+# Extending a data frame pads its other columns, and `[<-.data.frame` does that
+# through `length<-`.  Without this method the cell column stays short and the
+# frame is refused with "replacement has N rows, data has N+1".
+#' @export
+`length<-.xl_cell_general` <- function(x, value) {
+  recs <- .cell_records(x)
+  length(recs) <- value
+  .new_cell_vector(.fill_empty_cells(recs))
+}
+
+# `[<-` and `length<-` can both leave NULL holes past the old end.  A hole is a
+# cell with nothing in it, which is what an unwritten cell already means.
+.fill_empty_cells <- function(recs) {
+  holes <- vapply(recs, is.null, logical(1))
+  if (any(holes))
+    recs[holes] <- list(.cell_records(xl_cell_general(value = NA))[[1L]])
+  recs
 }
 
 #' @export
 c.xl_cell_general <- function(x, ...) {
-  structure(c(unclass(x), ...), class = class(x))
+  parts <- lapply(list(x, ...), function(el)
+    if (inherits(el, "xl_cell_general")) .cell_records(el)
+    else .cell_records(xl_cell_general(value = el)))
+  .new_cell_vector(do.call(c, parts))
 }
 
 #' @export
 rep.xl_cell_general <- function(x, ...) {
-  structure(rep(unclass(x), ...), class = class(x))
+  .new_cell_vector(rep(.cell_records(x), ...))
 }
 
 #' @export
@@ -431,7 +525,7 @@ print.xl_cell_general <- function(x, max = 10L, ...) {
   cat(sprintf("[xl_cell_general: %d cell%s]\n", n, if (n == 1L) "" else "s"))
   show <- seq_len(min(n, max))
   for (i in show) {
-    cell  <- unclass(x)[[i]]
+    cell  <- .cell_records(x)[[i]]
     parts <- character(0L)
 
     val <- cell[["value"]]

--- a/R/xl_filter.R
+++ b/R/xl_filter.R
@@ -83,7 +83,7 @@
 }
 
 .filter_cells_general <- function(x, nm) {
-  recs <- unclass(x)
+  recs <- .cell_records(x)
   n <- length(recs)
   num <- rep(NA_real_, n)
   txt <- rep(NA_character_, n)

--- a/R/xl_sheet.R
+++ b/R/xl_sheet.R
@@ -382,7 +382,7 @@ print.xl_sheet <- function(x, ...) {
 # Per-cell display width for a column (0 for blank/NA cells).
 .content_nchar <- function(col) {
   if (inherits(col, "xl_cell_general")) {
-    vapply(unclass(col), function(rec) {
+    vapply(.cell_records(col), function(rec) {
       s <- .cell_display_string(rec)
       if (is.na(s)) 0L else nchar(s, type = "width")
     }, integer(1))

--- a/man/xl_cell_general.Rd
+++ b/man/xl_cell_general.Rd
@@ -110,8 +110,14 @@ that combine multiple features (e.g., a formula with a pre-calculated
 result, or a URL with separate display text and tooltip).
 
 An `xl_cell_general` behaves like a vector: it has a `length()`, supports
-`[`, `c()`, and `rep()`, and recycles automatically when assigned to a
-data frame column of a different length (just like [xl_formula()]).
+`[`, `[[`, `c()` and `rep()`, and recycles automatically when assigned to a
+data frame column of a different length (just like [xl_formula()]).  It is
+deliberately not a list, so that `df[, j] <- cells` assigns one column
+rather than being read as a list of them.
+
+`df[i, j] <- x` sets that cell's `value`, whatever `x`'s type; a formula
+needs [xl_formula()], since a cell column carries no column-wide notion of
+"these are all formulas".
 
 `as.character()` returns what each cell displays, so a cell built for a sheet
 can be reused wherever a plain string is wanted --- [xl_merge()]'s or

--- a/src/write_xlsx.c
+++ b/src/write_xlsx.c
@@ -1901,7 +1901,11 @@ static void write_rich_string_cell(cell_write_ctx *ctx, lxw_row_t row,
 static void write_cell_general(cell_write_ctx *ctx,
                                 lxw_row_t row, lxw_col_t col_idx,
                                 SEXP col, lxw_row_t i){
-  SEXP cell      = VECTOR_ELT(col, (R_xlen_t) i);
+  /* the column is an integer carrier; the per-cell records ride along in an
+     attribute, so that `df[, j] <- cells` reaches [<-.data.frame as one column
+     rather than as a list of them */
+  SEXP recs      = Rf_getAttrib(col, Rf_install("records"));
+  SEXP cell      = VECTOR_ELT(recs, (R_xlen_t) i);
   SEXP value     = list_get(cell, "value");
   SEXP formula   = list_get(cell, "formula");
   SEXP hyperlink = list_get(cell, "hyperlink");

--- a/tests/testthat/test-cell-general.R
+++ b/tests/testthat/test-cell-general.R
@@ -212,7 +212,11 @@ test_that("as.data.frame.xl_cell_general: data.frame() uses the argument name", 
   expect_null(names(as.data.frame(x)))
   df <- data.frame(a = 1:3, my_col = x)
   expect_equal(names(df), c("a", "my_col"))
-  expect_true(is.list(df$my_col))
+  # not a list, and that is the point: `[<-.data.frame` reads a list value as a
+  # list of columns, so a list-backed cell vector could not be assigned with
+  # `df[, j] <-` at all
+  expect_s3_class(df$my_col, "xl_cell_general")
+  expect_false(is.list(df$my_col))
 })
 
 test_that("rep.xl_cell_general with length.out", {

--- a/tests/testthat/test-cell-vector.R
+++ b/tests/testthat/test-cell-vector.R
@@ -1,0 +1,166 @@
+# An xl_cell_general is a vector, not a list.
+#
+# The distinction is not cosmetic.  `[<-.data.frame` branches on
+# is.list(value): a list is read as a *list of columns*, so a list-backed cell
+# vector could not be assigned with `df[, j] <- cells` at all -- it scattered
+# one record per column and dropped the class, which is how writexl 2.0.0 broke
+# a reverse dependency that had worked since 1.5.4.
+#
+# The carrier is an integer index; the per-cell records ride in an attribute,
+# the shape factor uses.  These tests pin the vector behaviour rather than the
+# representation, except where the representation *is* the behaviour.
+
+test_that("a cell vector is not a list", {
+  x <- xl_cell_general(value = 1:3)
+  expect_false(is.list(x))
+  expect_type(unclass(x), "integer")
+  expect_length(x, 3L)
+  # the records are the content, and there is one per cell
+  expect_length(.cell_records(x), 3L)
+})
+
+test_that("mixed types survive: the carrier constrains nothing", {
+  x <- xl_cell_general(value = list(1.5, "text", TRUE, as.Date("2024-01-01")))
+  expect_equal(vapply(.cell_records(x), function(r) class(r$value)[1L],
+                      character(1)),
+               c("numeric", "character", "logical", "Date"))
+  # and they reach the file as their own types.  The Date arrives as its Excel
+  # serial rather than a formatted date: a mixed cell column carries no column
+  # number format, which is behaviour this rewrite inherited unchanged --
+  # verified identical against the pre-rewrite tree, and pinned here so that
+  # fixing it is a deliberate act rather than an accident.
+  p <- write_tmp(data.frame(a = 1:4, b = x))
+  got <- as.data.frame(readxl::read_xlsx(p))
+  expect_equal(got$b, c("1.5", "text", "TRUE", "45292"))
+})
+
+# ── Assignment into a data frame ──────────────────────────────────────────────
+
+test_that("`df[, j] <- cells` keeps the class, which is the whole point", {
+  d <- data.frame(a = 1:3)
+  d[, 2] <- xl_cell_general(value = 4:6)
+  expect_s3_class(d[[2]], "xl_cell_general")
+  expect_length(.cell_records(d[[2]]), 3L)
+})
+
+test_that("the pattern that broke a reverse dependency works", {
+  # BioMonTools seeds a one-row frame with a formula cell, then fills rows in
+  # one at a time.  Under a list-backed cell vector the seed warned, dropped
+  # the class, and left a bare list column that write_xlsx() refused.
+  NOTES <- data.frame(matrix(ncol = 3))
+  NOTES[, 2] <- xl_formula('=""')
+  expect_s3_class(NOTES[[2]], "xl_cell_general")
+
+  NOTES[1, 1] <- "Title"
+  NOTES[3, 2] <- "=LEFT(A1,1)"
+  expect_s3_class(NOTES[[2]], "xl_cell_general")
+  # the carrier and the records stay in step: a stale record list is how this
+  # corrupts silently rather than loudly
+  expect_length(.cell_records(NOTES[[2]]), length(NOTES[[2]]))
+  expect_equal(nrow(NOTES), length(NOTES[[2]]))
+  expect_equal(.cell_records(NOTES[[2]])[[3L]]$value, "=LEFT(A1,1)")
+
+  expect_silent(write_tmp(list(NOTES = NOTES)))
+})
+
+test_that("`df[i, j] <- value` reaches the record, not the carrier", {
+  d <- data.frame(a = 1:3)
+  d[, 2] <- xl_cell_general(value = c(10, 20, 30))
+  d[2, 2] <- 99
+  expect_s3_class(d[[2]], "xl_cell_general")
+  expect_equal(.cell_records(d[[2]])[[2L]]$value, 99)
+  # unchanged cells keep theirs
+  expect_equal(.cell_records(d[[2]])[[1L]]$value, 10)
+  # and an xl_cell_general on the right replaces the cell outright
+  d[3, 2] <- xl_cell_general(formula = "=A1+1")
+  expect_equal(.cell_records(d[[2]])[[3L]]$formula, "=A1+1")
+})
+
+test_that("the other ways a cell column gets built still work", {
+  x <- xl_cell_general(value = 1:3)
+  d <- data.frame(a = 1:3)
+  d$b <- x
+  expect_s3_class(d$b, "xl_cell_general")
+  expect_s3_class(data.frame(a = 1:3, b = x)$b, "xl_cell_general")
+  d2 <- data.frame(a = 1:3)
+  d2[["c"]] <- x
+  expect_s3_class(d2$c, "xl_cell_general")
+})
+
+# ── Vector semantics ──────────────────────────────────────────────────────────
+
+test_that("subsetting, concatenation and repetition act on cells", {
+  x <- xl_cell_general(value = c(1, 2, 3))
+  expect_length(x[2:3], 2L)
+  expect_equal(x[2:3][[1L]]$value, 2)
+  expect_length(c(x, x), 6L)
+  expect_length(rep(x, 2L), 6L)
+  expect_length(rep(x, length.out = 5L), 5L)
+  # `[[` is one cell's record, never the carrier's integer
+  expect_type(x[[1L]], "list")
+  expect_equal(x[[1L]]$value, 1)
+})
+
+test_that("a cell vector round-trips through a write unchanged by the rewrite", {
+  # the representation changed; what reaches the file must not have
+  df <- data.frame(a = 1:3)
+  df$b <- xl_cell_general(value = list(1, "two", NA),
+                          formula = c(NA, NA, "=A2+1"),
+                          format = xl_font(bold = TRUE))
+  p <- write_tmp(list(D = df))
+  x <- xlsx_part(p, "xl/worksheets/sheet1.xml", raw = TRUE)
+  expect_match(x, "A2+1", fixed = TRUE)
+  expect_match(xlsx_part(p, "xl/styles.xml", raw = TRUE), "<b/>", fixed = TRUE)
+  got <- as.data.frame(readxl::read_xlsx(p))
+  expect_equal(got$b[1L], "1")
+  expect_equal(got$b[2L], "two")
+})
+
+test_that("assigning a bare string writes a string, not a formula", {
+  # writexl's model is per cell: a formula is xl_formula(), anything else is a
+  # value.  writexl 1.5.4 carried the "this is a formula column" idea on the
+  # column's class, so a string assigned into one became a formula; there is no
+  # column-level kind here, and `d[i, j] <- "=A1"` writes the six characters.
+  d <- data.frame(a = 1:2)
+  d[, 2] <- xl_formula(c("=A1", "=A2"))
+  d[2, 2] <- "=SUM(A1:A2)"
+  expect_equal(.cell_records(d[[2]])[[2L]]$value, "=SUM(A1:A2)")
+  expect_true(is.na(.cell_records(d[[2]])[[2L]]$formula))
+  # the formula spelling is explicit, and still available
+  d[2, 2] <- xl_formula("=SUM(A1:A2)")
+  expect_equal(.cell_records(d[[2]])[[2L]]$formula, "=SUM(A1:A2)")
+})
+
+test_that("a frame extended past a cell column pads it with empty cells", {
+  # R extends rows behind our back, through xpdrows.data.frame(); the records
+  # are padded on read so the new cells are blank rather than absent
+  d <- data.frame(matrix(ncol = 2))
+  d[, 1] <- xl_cell_general(value = 1)
+  d[4, 2] <- "x"
+  expect_equal(nrow(d), 4L)
+  expect_length(d[[1]], 4L)
+  expect_length(.cell_records(d[[1]]), 4L)
+  expect_true(is.na(.cell_records(d[[1]])[[3L]]$value))
+  expect_silent(write_tmp(list(D = d)))
+})
+
+test_that("`[[<-` replaces one cell's record", {
+  x <- xl_cell_general(value = c(1, 2, 3))
+  x[[2L]] <- .cell_records(xl_cell_general(formula = "=A1"))[[1L]]
+  expect_s3_class(x, "xl_cell_general")
+  expect_equal(x[[2L]]$formula, "=A1")
+  expect_equal(x[[1L]]$value, 1)
+  expect_length(x, 3L)
+})
+
+test_that("`length<-` grows and shrinks a cell vector", {
+  x <- xl_cell_general(value = c(1, 2, 3))
+  length(x) <- 5L
+  expect_length(x, 5L)
+  expect_length(.cell_records(x), 5L)
+  # the new cells are empty rather than absent
+  expect_true(is.na(x[[5L]]$value))
+  length(x) <- 2L
+  expect_length(x, 2L)
+  expect_equal(x[[2L]]$value, 2)
+})

--- a/tests/testthat/test-format-cell.R
+++ b/tests/testthat/test-format-cell.R
@@ -3,18 +3,18 @@
 
 test_that("xl_cell_general accepts a single format, a list, or NULL", {
   x <- xl_cell_general(value = 1:3, format = xl_font(bold = TRUE))
-  expect_true(is_xl_format(unclass(x)[[1]]$format))
-  expect_true(is_xl_format(unclass(x)[[3]]$format))
+  expect_true(is_xl_format(x[[1]]$format))
+  expect_true(is_xl_format(x[[3]]$format))
 
   # per-cell list, recycled
   y <- xl_cell_general(value = 1:2,
                        format = list(xl_font(bold = TRUE), xl_font(italic = TRUE)))
-  expect_true(unclass(unclass(y)[[1]]$format)$font$bold)
-  expect_true(unclass(unclass(y)[[2]]$format)$font$italic)
+  expect_true(unclass(y[[1]]$format)$font$bold)
+  expect_true(unclass(y[[2]]$format)$font$italic)
 
   # NULL -> no format
   z <- xl_cell_general(value = 1:2)
-  expect_null(unclass(z)[[1]]$format)
+  expect_null(z[[1]]$format)
 
   expect_error(xl_cell_general(value = 1, format = list("bad")),
                "must be an xl_format")


### PR DESCRIPTION
Fixes the reverse-dependency breakage CRAN's pretest found in BioMonTools.

## The problem

`[<-.data.frame` branches on `is.list(value)`, and reads a list as a *list of
columns*. `xl_cell_general` was a list of per-cell records, so

```r
df[, j] <- cells
```

scattered one record per column, warned, and dropped the class — leaving a bare
list column that `write_xlsx()` then refused:

```
writexl cannot write column(s) of these types:
'X2' (column 2): list
```

BioMonTools had done exactly this since 1.5.4, when `xl_formula()` returned a
classed character vector and the assignment worked.

Nothing could be patched around it. A plain list fails the same way, `I()`
doesn't help, `AsIs` in the class doesn't help, and writexl cannot define
`[<-.data.frame` without pirating a method that affects every data frame in the
session.

## The change

The records are unchanged. What moves is where they live:

```r
structure(seq_along(records), records = records,
          class = c("xl_cell_general", "xl_cell"))
```

An integer index carrying the records in an attribute — the shape `factor`
uses. Being an atomic vector is the point: `is.list()` is false, so
`[<-.data.frame` treats it as one column.

The carrier is an integer rather than the displayed text deliberately. If the
class is ever stripped — recycling into a longer frame does it, in base R and in
1.5.4 alike — an integer leaves an obviously wrong `1, 2, 3` rather than
plausible-looking text that would write as silently wrong cells.

## Three things the implementation turned up

* **`[<-` is load-bearing, not a convenience.** Without it, `d[i, j] <- v`
  writes into the carrier — silently — and leaves the records one short.
* **`[[` needs a method too**, or `x[[i]]` answers with the carrier's integer
  instead of the cell. The suite caught this immediately, which is the integer
  carrier earning its keep: it errored rather than returning something
  plausible.
* **R extends a frame's rows behind every method's back.**
  `xpdrows.data.frame()` does `class(y) <- NULL; length(y) <- n;
  attributes(y) <- saved` — no hook exists, and the short record list comes
  straight back. So the *carrier* is the authority on length and
  `.cell_records()` pads on read; the new cells then read as empty, which is
  what extending a frame means.

## What it does and does not fix

BioMonTools' original, unpatched code now runs. But its
`NOTES[3, 2] <- "=LEFT(...)"` assignments write **text, not formulas** — 2
formula cells where the sheet wants 62.

That is writexl's model: `df[i, j] <- x` sets that cell's `value`, and a formula
needs `xl_formula()`. writexl 1.5.4 differed only because it carried "this is a
formula column" on the column's *class*, which a per-cell model has nowhere to
put. A test pins the difference so it is deliberate rather than discovered.

**So the BioMonTools patch is still wanted.** This removes the error; the patch
is what preserves the formulas. It works against 1.5.4 and 2.0.0 alike.

## Verification

* `R CMD check --as-cran`: 0 errors, 0 warnings, 0 notes
* `lintr::lint_package()`: 0
* **100% of every R line**; `src/write_xlsx.c` 99.26%, the same defensive lines
  as before
* `test-cell-vector.R` covers the BioMonTools pattern, every way a cell column
  gets built (`[, j] <-`, `[[j]] <-`, `$<-`, `data.frame()`), mixed types
  reaching the file, and the vector semantics
* Two representation-pinning tests were inverted on purpose: one asserted the
  column *is* a list, which is precisely what had to change

## Follow-ups, not in this PR

1. **The revdep results in `cran-comments.md` predate this.** It touches the
   object every reverse dependency uses, so a fresh `revdepcheck` before
   submitting matters more now, not less.
2. **A pre-existing bug found in passing:** a `Date` inside a *mixed*
   `xl_cell_general` column writes as a bare serial (`45292`) with no date
   format. Confirmed identical on master, so not from this work; pinned in a
   test with a comment so a fix is deliberate. Worth its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)