### PR TITLE
Fix C23 const-correctness warnings in vendored libxlsxwriter (CRAN WARN on r-devel Fedora)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: writexl
 Type: Package
 Title: Export Data Frames to Excel 'xlsx' Format
-Version: 2.0.0
+Version: 2.0.1
 Authors@R: c(
     person("Jeroen", "Ooms", role = "aut", comment = c(ORCID = "0000-0002-4035-0289")),
     person("Bill", "Denney", ,"wdenney@humanpredictions.com", role = c("aut", "cre"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,14 @@
+# writexl 2.0.1
+
+A compiled-code cleanup requested by CRAN; nothing changes at the R level.
+
+* The bundled libxlsxwriter assigned the result of `strstr()`/`strpbrk()` on a
+  `const` string to a non-`const` pointer in four places. With GCC 16 and
+  glibc 2.43, where the C23 `<string.h>` search functions preserve `const`,
+  those assignments drew "discards 'const' qualifier" warnings, and the CRAN
+  checks on the r-devel Fedora flavors flag them as significant. The pointers
+  were only ever read, and are now `const` (or gone).
+
 # writexl 2.0.0
 
 writexl is now maintained by Bill Denney; Jeroen Ooms remains an author.

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,36 +1,24 @@
-# writexl 2.0.0
+# writexl 2.0.1
 
-This is a resubmission. The previous submission's pretest reported a reverse
-dependency, BioMonTools, as a change to worse which has now been fixed by an
-updated version of BioMonTools which works under both the current CRAN
-version and this version of writexl.
+This release fixes the WARN on the r-devel Fedora flavors, requested by CRAN
+before 2026-08-21. GCC 16 with glibc 2.43 makes the C23 `<string.h>` search
+functions const-correct, so four assignments in the bundled libxlsxwriter
+(`src/libxlsxwriter/src/worksheet.c`) discarded a `const` qualifier:
 
-## Change of maintainer
+```
+libxlsxwriter/src/worksheet.c:1979:9: warning: assignment discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
+libxlsxwriter/src/worksheet.c:8420:18: warning: assignment discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
+libxlsxwriter/src/worksheet.c:8425:18: warning: assignment discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
+libxlsxwriter/src/worksheet.c:8436:26: warning: assignment discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
+```
 
-The maintainer changes with this release, from Jeroen Ooms
-(jeroenooms@gmail.com) to Bill Denney (wdenney@humanpredictions.com). Jeroen
-Ooms remains an author. He confirmed the change to CRAN by email during the
-previous submission, and CRAN acknowledged it.
+The pointers involved are never written through; they are now declared
+`const` or the search result is tested directly. The warnings were reproduced
+and confirmed gone by compiling the package's C sources with the C23
+const-correct `<string.h>` semantics; the same change is being proposed to
+upstream libxlsxwriter, which has the same code on its main branch.
 
-## Why the major version
-
-Most of this release is additive, but these change what an existing script
-writes, so the version is 2.0.0 rather than 1.6.0:
-
-* `POSIXct` columns are no longer silently converted to UTC.
-* `Date` values before 1900-03-01 were written one day too late and now agree
-  with `POSIXct`.
-* Columns of a type the package cannot represent are an error rather than a
-  warning with empty cells.
-* Sheet-name repair truncates to a genuine 31 characters rather than 29.
-* A formula is a property of a cell rather than of a column, so
-  `df[i, j] <- "=SUM(A1:A2)"` writes text and warns, where 1.5.4 wrote a
-  formula. This is the BioMonTools case above.
-
-`xl_hyperlink(name = )` is deprecated in favour of `value`. `value` occupies the
-argument position `name` used to, so positional calls are unaffected; supplying
-`name` warns rather than failing. All of these are listed under "Breaking
-changes" in NEWS.md.
+There are no R-level changes.
 
 ## Test environments
 
@@ -46,13 +34,7 @@ changes" in NEWS.md.
 
 ## Reverse dependencies
 
-writexl has 87 strong reverse dependencies and 135 including Suggests.
-
-All 135 were checked with revdepcheck against both the CRAN version and this
-one. BioMonTools, has been re-checked individually against the current sources
-as described. No other package changed its check result.
-
-One package, ggpaintr, did not finish that run: its vignette hangs at "checking
-running R code from vignettes", identically against both versions, so the hang
-is a property of that package in the check environment rather than a change
-here.
+This release changes no R-level interface or behavior; the only change
+removes compiler warnings from the bundled C library. Reverse dependencies
+were checked in full with revdepcheck for 2.0.0, published 2026-08-05, and
+this release makes no R-level change on top of it.

--- a/src/libxlsxwriter/src/worksheet.c
+++ b/src/libxlsxwriter/src/worksheet.c
@@ -1947,7 +1947,7 @@ lxw_error
 _check_table_name(lxw_table_options *user_options)
 {
     const char *name;
-    char *ptr;
+    const char *ptr;
     char first[2] = { 0, 0 };
 
     if (!user_options)
@@ -8417,13 +8417,11 @@ worksheet_write_url_opt(lxw_worksheet *self,
     err = LXW_ERROR_MEMORY_MALLOC_FAILED;
 
     /* Set the URI scheme from internal links. */
-    found_string = strstr(url, "internal:");
-    if (found_string)
+    if (strstr(url, "internal:"))
         link_type = HYPERLINK_INTERNAL;
 
     /* Set the URI scheme from external links. */
-    found_string = strstr(url, "external:");
-    if (found_string)
+    if (strstr(url, "external:"))
         link_type = HYPERLINK_EXTERNAL;
 
     if (string) {
@@ -8433,8 +8431,7 @@ worksheet_write_url_opt(lxw_worksheet *self,
     else {
         if (link_type == HYPERLINK_URL) {
             /* Strip the mailto header. */
-            found_string = strstr(url, "mailto:");
-            if (found_string)
+            if (strstr(url, "mailto:"))
                 string_copy = lxw_strdup(url + sizeof("mailto"));
             else
                 string_copy = lxw_strdup(url);


### PR DESCRIPTION
Fixes #148

## What CRAN reported

The r-devel Fedora flavors (gcc and clang) WARN on installation with four
[significant warnings](https://cran.r-project.org/web/checks/check_results_writexl.html):

```
libxlsxwriter/src/worksheet.c:1979:9: warning: assignment discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
libxlsxwriter/src/worksheet.c:8420:18: warning: assignment discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
libxlsxwriter/src/worksheet.c:8425:18: warning: assignment discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
libxlsxwriter/src/worksheet.c:8436:26: warning: assignment discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
```

## Root cause

GCC 16 defaults to C23, and glibc 2.43 makes the C23 `<string.h>` search
functions const-correct: `strstr()`/`strpbrk()` on a `const char *` now
return `const char *` (via glibc's `__glibc_const_generic` macros).
`worksheet.c` assigned those results to plain `char *`.

## Why a local patch to the vendored tree

Upstream `main` (checked 2026-08-07) still has the same declarations, so
re-vendoring current upstream would not fix this. The patch is minimal and
should apply upstream as-is; it will be reported to jmcnamara/libxlsxwriter
so the next vendored bump does not reintroduce the warnings.

## The fix

* `_check_table_name()`: `ptr` is only ever read through, so it becomes
  `const char *`.
* `worksheet_write_url_opt()`: the three scheme probes (`internal:`,
  `external:`, `mailto:`) only null-test the `strstr()` result, so they now
  test it directly. `found_string` stays `char *` because it is later
  assigned from `strchr()` on the mutable `url_copy` and written through
  (`*found_string = '\0'`).

## Replication

Compiled all 31 C files from `src/Makevars` with Rtools gcc 14.3
(`-std=gnu23`, CRAN's warning flags) force-including a shim header that
copies glibc 2.43's `__glibc_const_generic` and its five per-function
`<string.h>` macros verbatim:

* before: exactly the four CRAN warnings, matching file, line, and column,
  and nothing else in the tree;
* after: zero warnings;
* plain gcc 14.3 without the shim (i.e. every OK CRAN flavor): zero
  warnings before and after.

## Verification

`R CMD check` on R 4.6.1 / Windows (`--no-manual --no-vignettes`): the
install log has zero compiler warnings, all tests pass, and the only
WARNINGs are the two expected artifacts of skipping vignette building.
No R-level changes.

## Release bits

Version 2.0.1 with NEWS entry and updated cran-comments.md, since CRAN
requires a release before 2026-08-21.

🤖 Generated with [Claude Code](https://claude.com/claude-code)